### PR TITLE
 Add security codes migration service from old soap service to compatible with new Rest service.

### DIFF
--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/pom.xml
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>org.wso2.carbon.identity.securitycode.migration</artifactId>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - Identity Security Code Migration</name>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/pom.xml
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2</groupId>
+        <artifactId>wso2</artifactId>
+        <version>1</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.sample</groupId>
+    <artifactId>org.wso2.carbon.identity.securitycode.migration</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Identity Security Code Migration</name>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+            <version>${identity.governance.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <version>${felix.scr.annotations.version}</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>${maven.scr.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>
+                            ${project.artifactId}
+                        </Bundle-SymbolicName>
+                        <Private-Package>
+                            org.wso2.carbon.identity.securitycode.migration.internal
+                        </Private-Package>
+                        <Export-Package>
+                            org.wso2.carbon.identity.securitycode.migration.*;
+                            version="${identity.code.migration.exp.pkg.version}",
+                            !org.wso2.carbon.identity.securitycode.migration
+                        </Export-Package>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.*;version="${carbon.identity.framework.version.range}",
+                            org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <properties>
+
+        <!--Carbon Identity Framework Version-->
+        <carbon.identity.framework.version>5.11.10</carbon.identity.framework.version>
+        <carbon.identity.framework.version.range>[5.0.0, 6.0.0]</carbon.identity.framework.version.range>
+        <identity.code.migration.exp.pkg.version>${project.version}</identity.code.migration.exp.pkg.version>
+        <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
+        <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
+        <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <felix.scr.annotations.version>1.2.4</felix.scr.annotations.version>
+        <carbon.kernel.version>4.4.23</carbon.kernel.version>
+        <maven.compiler.plugin>3.7.0</maven.compiler.plugin>
+        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
+        <maven.scr.plugin.version>1.22.0</maven.scr.plugin.version>
+        <identity.governance.version>1.0.37</identity.governance.version>
+        <identity.governance.version.range>[1.0.0, 2.0.0]</identity.governance.version.range>
+    </properties>
+</project>

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/MigrationConstants.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/MigrationConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations und
+ */
+package org.wso2.carbon.identity.securitycode.migration;
+
+/**
+ * This class is used to define the constants used in security code migration.
+ */
+public class MigrationConstants {
+
+    public static final String CONFIRMATION_REGISTRY_RESOURCE_PATH = "/repository/components/org.wso2.carbon" +
+            ".identity.mgt/data/";
+    public static final String EXPIRE_TIME_PROPERTY = "expireTime";
+    public static final String USER_ID_PROPERTY = "userId";
+    public static final String SELF_SIGN_UP_CODE_DELIMITER = "1";
+    public static final String PW_RESET_CODE_DELIMITER = "2";
+    public static final String REG_DELIMITER = "___";
+    public static final String TENANT_DELIMITER = ":";
+    public static final String SYSTEM_PROPERTY_MIGRATE = "migrateSecurityCode";
+    public static final String SYSTEM_PROPERTY_TENANTS = "tenantsToMigrate";
+
+
+}

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/MigrationConstants.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/MigrationConstants.java
@@ -29,7 +29,10 @@ public class MigrationConstants {
     public static final String REG_DELIMITER = "___";
     public static final String TENANT_DELIMITER = ":";
     public static final String SYSTEM_PROPERTY_MIGRATE = "migrateSecurityCode";
-    public static final String SYSTEM_PROPERTY_TENANTS = "tenantsToMigrate";
+    public static final String SYSTEM_PROPERTY_MIGRATE_TENANTS = "migrateTenants";
+    public static final String SYSTEM_PROPERTY_MIGRATE_TENANT_RANGE = "migrateTenantRange";
+    public static final String SYSTEM_PROPERTY_START_TENANT = "tenantStartNo";
+    public static final String SYSTEM_PROPERTY_TENANT_COUNT = "tenantCount";
 
 
 }

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/internal/IdentityCodeMigrationServiceComponent.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/internal/IdentityCodeMigrationServiceComponent.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.securitycode.migration.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
+import org.wso2.carbon.identity.securitycode.migration.service.SecurityCodeMigrationService;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.SYSTEM_PROPERTY_MIGRATE;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.SYSTEM_PROPERTY_TENANTS;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.TENANT_DELIMITER;
+
+@Component(
+        name = "IdentityCodeMigrationServiceComponent",
+        immediate = true
+)
+public class IdentityCodeMigrationServiceComponent {
+
+    private static Log log = LogFactory.getLog(IdentityCodeMigrationServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Security code migration bundle is activated");
+        }
+
+        SecurityCodeMigrationService securityCodeMigrationService = new SecurityCodeMigrationService();
+        String migrateCode = System.getProperty(SYSTEM_PROPERTY_MIGRATE);
+        String tenantToMigrate = System.getProperty(SYSTEM_PROPERTY_TENANTS);
+
+        if (log.isDebugEnabled()) {
+            log.debug("migrateCode: " + migrateCode);
+            log.debug("Tenant to Migrate: " + tenantToMigrate);
+        }
+
+        try {
+            if (migrateAll(migrateCode, tenantToMigrate)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Migrating security codes of all tenants started");
+                }
+                securityCodeMigrationService.migrateAllTenants();
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Migrating security codes of all tenants ended");
+                }
+            } else if (Boolean.parseBoolean(migrateCode) && isNotBlank(tenantToMigrate)) {
+                String[] tenantDomains = tenantToMigrate.split(TENANT_DELIMITER);
+                securityCodeMigrationService.migrateTenants(tenantDomains);
+            }
+        } catch (Throwable throwable) {
+            log.error(throwable);
+        }
+    }
+
+    protected void deactivate(ComponentContext context) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Security code migration bundle is de-activated");
+        }
+    }
+
+    @Reference(
+            name = "realm.service",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService"
+    )
+    protected void setRealmService(RealmService realmService) {
+
+        log.debug("Setting the Realm Service");
+        IdentityCodeMigrationServiceDataHolder.setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        log.debug("UnSetting the Realm Service");
+        IdentityCodeMigrationServiceDataHolder.setRealmService(null);
+    }
+
+    @Reference(
+            name = "registry.service",
+            service = RegistryService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRegistryService"
+    )
+    protected void setRegistryService(RegistryService registryService) {
+
+        log.debug("Setting the Registry Service");
+        IdentityCodeMigrationServiceDataHolder.setRegistryService(registryService);
+    }
+
+    protected void unsetRegistryService(RegistryService registryService) {
+
+        log.debug("UnSetting the Registry Service");
+        IdentityCodeMigrationServiceDataHolder.setRegistryService(null);
+    }
+
+    @Reference(
+            name = "identityCoreInitializedEventService",
+            service = IdentityCoreInitializedEvent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityCoreInitializedEventService"
+    )
+    protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is started */
+    }
+
+    protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is started */
+    }
+
+    private boolean migrateAll(String migrateCode, String tenantToMigrate) {
+
+        return Boolean.parseBoolean(migrateCode) && isBlank(tenantToMigrate);
+    }
+}
+

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/internal/IdentityCodeMigrationServiceDataHolder.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/internal/IdentityCodeMigrationServiceDataHolder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.securitycode.migration.internal;
+
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class is used to hold the registered services.
+ */
+public class IdentityCodeMigrationServiceDataHolder {
+
+    private static RealmService realmService;
+    private static RegistryService registryService;
+
+    public static RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public static void setRealmService(RealmService realmService) {
+
+        IdentityCodeMigrationServiceDataHolder.realmService = realmService;
+    }
+
+    public static RegistryService getRegistryService() {
+
+        return registryService;
+    }
+
+    public static void setRegistryService(RegistryService registryService) {
+
+        IdentityCodeMigrationServiceDataHolder.registryService = registryService;
+    }
+}

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/service/SecurityCodeMigrationService.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/service/SecurityCodeMigrationService.java
@@ -95,23 +95,35 @@ public class SecurityCodeMigrationService {
 
         startTenantFlow(tenantDomain);
         try {
+            IdentityTenantUtil.getTenantRegistryLoader().loadTenantRegistry(tenantId);
             Registry registry = getConfigSystemRegistry(tenantId);
             String[] identityResourcesPaths = getIdentityResourcesPaths(registry);
             if (!isEmpty(identityResourcesPaths)) {
                 for (String path : identityResourcesPaths) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("The resource path :" + path);
+                    }
+
                     Resource currentResource = registry.get(path);
                     if (currentResource instanceof CollectionImpl) {
                         String[] resources = ((CollectionImpl) currentResource).getChildren();
                         for (String resource : resources) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Migrating resource :" + registry.get(resource) + "of tenant :" + tenantDomain);
+                            }
                             migrateCodeFromRegistryResource(tenantDomain, registry.get(resource));
                         }
                     } else if (currentResource instanceof ResourceImpl) {
                         migrateCodeFromRegistryResource(tenantDomain, currentResource);
                     }
+
                 }
             }
         } catch (RegistryException e) {
-            log.error("Error occurred while migrating codes of tenant: " + tenantDomain, e);
+            log.error("Error occurred while migrating codes of tenant: " + tenantDomain);
+            if (log.isDebugEnabled()) {
+                log.error(e);
+            }
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
@@ -120,6 +132,10 @@ public class SecurityCodeMigrationService {
     private void migrateCodeFromRegistryResource(String tenantDomain, Resource currentResource) {
 
         if (isCodeNotValid(currentResource)) {
+            if (log.isDebugEnabled()) {
+                log.debug("The code in the current resource: " + currentResource + "  is not valid, its Expired for" +
+                        " the tenant domain : " + tenantDomain);
+            }
             return;
         }
         String resourceName = currentResource.getPath().replace(CONFIRMATION_REGISTRY_RESOURCE_PATH, "");

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/service/SecurityCodeMigrationService.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/service/SecurityCodeMigrationService.java
@@ -66,6 +66,14 @@ public class SecurityCodeMigrationService {
         }
     }
 
+    public void migrateTenantRange(int startTenantID, int tenantCount) {
+
+        migrateSuperTenantSecurityCodes();
+        for (int tenantId = startTenantID; tenantId < (tenantCount + startTenantID); tenantCount++) {
+            migrateSecurityCodes(IdentityTenantUtil.getTenantDomain(tenantId), tenantId);
+        }
+
+    }
     public void migrateTenants(String[] tenantDomains) {
 
         for (String tenantDomain : tenantDomains) {

--- a/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/service/SecurityCodeMigrationService.java
+++ b/identity-mgt/code-migration/org.wso2.carbon.identity.securitycode.migration/src/main/java/org/wso2/carbon/identity/securitycode/migration/service/SecurityCodeMigrationService.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations und
+ */
+package org.wso2.carbon.identity.securitycode.migration.service;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.securitycode.migration.internal.IdentityCodeMigrationServiceDataHolder;
+import org.wso2.carbon.registry.api.Resource;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.CollectionImpl;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.ResourceImpl;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.apache.commons.lang.ArrayUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.CONFIRMATION_REGISTRY_RESOURCE_PATH;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.EXPIRE_TIME_PROPERTY;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.PW_RESET_CODE_DELIMITER;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.REG_DELIMITER;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.SELF_SIGN_UP_CODE_DELIMITER;
+import static org.wso2.carbon.identity.securitycode.migration.MigrationConstants.USER_ID_PROPERTY;
+
+public class SecurityCodeMigrationService {
+
+    private static Log log = LogFactory.getLog(SecurityCodeMigrationService.class);
+
+    public void migrateAllTenants() {
+
+        try {
+            Tenant[] tenants = getAllTenants();
+            migrateSuperTenantSecurityCodes();
+            for (Tenant tenant : tenants) {
+                migrateSecurityCodes(tenant.getDomain(), tenant.getId());
+            }
+        } catch (UserStoreException e) {
+            log.error("Error while get all tenants. Security Migration skipped.", e);
+        }
+    }
+
+    public void migrateTenants(String[] tenantDomains) {
+
+        for (String tenantDomain : tenantDomains) {
+            if (log.isDebugEnabled()) {
+                log.debug("Started migrating security codes tenant: " + tenantDomain);
+            }
+            try {
+                int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+                migrateSecurityCodes(tenantDomain, tenantId);
+            } catch (IdentityRuntimeException e) {
+                log.error("Invalid tenant domain: " + tenantDomain);
+            }
+        }
+    }
+
+    private Tenant[] getAllTenants() throws UserStoreException {
+
+        return IdentityCodeMigrationServiceDataHolder.getRealmService().getTenantManager().getAllTenants();
+    }
+
+    private void migrateSuperTenantSecurityCodes() {
+
+        migrateSecurityCodes(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, MultitenantConstants.SUPER_TENANT_ID);
+    }
+
+    private void migrateSecurityCodes(String tenantDomain, int tenantId) {
+
+        startTenantFlow(tenantDomain);
+        try {
+            Registry registry = getConfigSystemRegistry(tenantId);
+            String[] identityResourcesPaths = getIdentityResourcesPaths(registry);
+            if (!isEmpty(identityResourcesPaths)) {
+                for (String path : identityResourcesPaths) {
+                    Resource currentResource = registry.get(path);
+                    if (currentResource instanceof CollectionImpl) {
+                        String[] resources = ((CollectionImpl) currentResource).getChildren();
+                        for (String resource : resources) {
+                            migrateCodeFromRegistryResource(tenantDomain, registry.get(resource));
+                        }
+                    } else if (currentResource instanceof ResourceImpl) {
+                        migrateCodeFromRegistryResource(tenantDomain, currentResource);
+                    }
+                }
+            }
+        } catch (RegistryException e) {
+            log.error("Error occurred while migrating codes of tenant: " + tenantDomain, e);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    private void migrateCodeFromRegistryResource(String tenantDomain, Resource currentResource) {
+
+        if (isCodeNotValid(currentResource)) {
+            return;
+        }
+        String resourceName = currentResource.getPath().replace(CONFIRMATION_REGISTRY_RESOURCE_PATH, "");
+        String userId = UserCoreUtil.addTenantDomainToEntry(currentResource.getProperty
+                (USER_ID_PROPERTY), tenantDomain);
+        User user = User.getUserFromUserName(userId);
+        if (resourceName.startsWith(SELF_SIGN_UP_CODE_DELIMITER)) {
+            migrateSelfRegistrationCode(resourceName, user);
+        } else if (resourceName.startsWith(PW_RESET_CODE_DELIMITER)) {
+            migratePasswordResetOrAskPasswordsCode(resourceName, user);
+        }
+    }
+
+    private String[] getIdentityResourcesPaths(Registry registry) throws RegistryException {
+
+        Collection identityDataResource = (Collection) registry.get(CONFIRMATION_REGISTRY_RESOURCE_PATH);
+        return identityDataResource.getChildren();
+    }
+
+    private UserRegistry getConfigSystemRegistry(int tenantId) throws RegistryException {
+
+        return IdentityCodeMigrationServiceDataHolder.getRegistryService().
+                getConfigSystemRegistry(tenantId);
+    }
+
+    private boolean isCodeNotValid(Resource currentResource) {
+
+        long currentTimeMillis = System.currentTimeMillis();
+        long resourceExpireTime = Long.parseLong(currentResource.getProperty(EXPIRE_TIME_PROPERTY));
+        return currentTimeMillis > resourceExpireTime;
+    }
+
+    private void migrateSelfRegistrationCode(String resourceName, User user) {
+
+        String secretKey = extractSecurityKey(resourceName);
+        if (isNotBlank(secretKey)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Migrating self sign-up code of user: " + user.toFullQualifiedUsername());
+            }
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey, RecoveryScenarios
+                    .SELF_SIGN_UP, RecoverySteps.CONFIRM_SIGN_UP);
+            try {
+                userRecoveryDataStore.store(recoveryDataDO);
+            } catch (IdentityRecoveryException e) {
+                log.error("Error while migrating self sign-up code of user: " + user.toFullQualifiedUsername());
+            }
+        } else {
+            log.warn("Invalid code: " + secretKey);
+        }
+    }
+
+    private void migratePasswordResetOrAskPasswordsCode(String resourceName, User user) {
+
+        String secretKey = extractSecurityKey(resourceName);
+        if (isNotBlank(secretKey)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Migrating password reset code of user: " + user.toFullQualifiedUsername());
+            }
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey, RecoveryScenarios
+                    .NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.UPDATE_PASSWORD);
+            try {
+                userRecoveryDataStore.store(recoveryDataDO);
+            } catch (IdentityRecoveryException e) {
+                log.error("Error while migrating security code of user: " + user.toFullQualifiedUsername());
+            }
+        } else {
+            log.warn("Invalid code: " + secretKey);
+        }
+    }
+
+    private void startTenantFlow(String tenantDomain) {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+    }
+
+    private String extractSecurityKey(String code) {
+
+        String[] splitCodes = code.split(REG_DELIMITER);
+        if (!isEmpty(splitCodes) && splitCodes.length == 3) {
+            return splitCodes[2];
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Purpose
> If a customer used old SOAP service to generate security codes if they migrate to our new REST Service they can't use old security codes. This client will migrate these old security codes to compatible with new REST service.

Resolved https://github.com/wso2/samples-is/issues/65