### PR TITLE
Updated apache httpcore dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <http.client.version>4.5.3</http.client.version>
-        <http.core.version>4.4.6</http.core.version>
+        <http.core.version>4.4.8</http.core.version>
         <commons-logging.version>1.2</commons-logging.version>
 
         <!--=============================================================================-->


### PR DESCRIPTION
## Purpose
> updated org.apache.httpcomponents httpcore dependency version. 
Fixes `java.lang.NoSuchMethodError: org.apache.http.impl.conn.CPool.setValidateAfterInactivity(I)V` error when testing SAML artifact binding. 

