### PR TITLE
Fixing a bug introduced from PR 132

### DIFF
--- a/oidc-sso-sample/oidc-jks-loader/src/main/org/wso2/sample/identity/jks/JKSLoader.java
+++ b/oidc-sso-sample/oidc-jks-loader/src/main/org/wso2/sample/identity/jks/JKSLoader.java
@@ -59,8 +59,8 @@ public class JKSLoader implements ServletContextListener {
 
         if (resource != null) {
             LOGGER.log(Level.INFO, "Setting trust store path to : " + resource.getPath());
-            System.setProperty("javax.net.ssl.trustStore.", resource.getPath());
-            System.setProperty("javax.net.ssl.trustStorePassword.", jksProperties.getProperty("keystorepassword"));
+            System.setProperty("javax.net.ssl.trustStore", resource.getPath());
+            System.setProperty("javax.net.ssl.trustStorePassword", jksProperties.getProperty("keystorepassword"));
         } else {
             LOGGER.log(Level.INFO, "Unable to find JKS defined by properties. Trust store properties will not be set.");
         }


### PR DESCRIPTION
## Purpose
There was a bug introduced from PR 132. This bug breaks the JKS keystore property setup at application startup

## Goals
Correcting the big and stabilise sample applications. 