### PR TITLE
Fix org.wso2.carbon.identity.agent.sso version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.agent.sso.java</groupId>
                 <artifactId>org.wso2.carbon.identity.sso.agent</artifactId>
-                <version>${identity.agent.sso.version.range}</version>
+                <version>${identity.agent.sso.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>opensaml.wso2</groupId>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/6927

Previously identity sso version was as <version>${identity.agent.sso.version.range}</version>. Since it gives the range, it takes the the latest opensaml3 when compiling