### PR TITLE
Downgrade identity.agent.sso version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
 
     <properties>
         <!--repo versions of quick-start-guide-->
-        <identity.agent.sso.version>5.4.0</identity.agent.sso.version>
+        <identity.agent.sso.version>5.1.22</identity.agent.sso.version>
         <sample.oidc-sso-sample.version>1.0</sample.oidc-sso-sample.version>
         <sample.qsg.version>1.0</sample.qsg.version>
         <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>


### PR DESCRIPTION
Reverts wso2/samples-is#224

Downgrading the identity.agent.sso as this version is working with openSAML 3.X but the sample apps are not yet updated and tested in openSAML 3.X