### PR TITLE
Javadoc check bypassed for migrated samples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -732,6 +732,22 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven.checkstyle.plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration> <!-- add this to disable checking -->
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -883,6 +899,7 @@
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
         <jsp.api.version>2.0</jsp.api.version>
         <ds-annotations.version>1.2.10</ds-annotations.version>
+        <maven.javadoc.version>2.10.1</maven.javadoc.version>
     </properties>
 
 </project>


### PR DESCRIPTION
Javadoc check for the migrated samples from Product-IS that caused release build failures bypassed.