### PR TITLE
Upgraded Java versions from 1.6 to 1.8 on few samples

### DIFF
--- a/authenticators/components/org.wso2.carbon.identity.sample.extension.auth.endpoint/pom.xml
+++ b/authenticators/components/org.wso2.carbon.identity.sample.extension.auth.endpoint/pom.xml
@@ -76,8 +76,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
                 <version>2.3.2</version>
             </plugin>

--- a/identity-mgt/info-recovery-sample/pom.xml
+++ b/identity-mgt/info-recovery-sample/pom.xml
@@ -132,8 +132,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/oauth2/custom-grant/pom.xml
+++ b/oauth2/custom-grant/pom.xml
@@ -73,8 +73,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/passive-sts/passive-sts-client/PassiveSTSFilter/pom.xml
+++ b/passive-sts/passive-sts-client/PassiveSTSFilter/pom.xml
@@ -70,8 +70,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/sts/sts-client/pom.xml
+++ b/sts/sts-client/pom.xml
@@ -90,8 +90,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/user-mgt/remote-user-mgt/pom.xml
+++ b/user-mgt/remote-user-mgt/pom.xml
@@ -72,8 +72,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/user-mgt/sample-custom-user-store-manager/pom.xml
+++ b/user-mgt/sample-custom-user-store-manager/pom.xml
@@ -41,8 +41,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/workflow/handler/service-provider/pom.xml
+++ b/workflow/handler/service-provider/pom.xml
@@ -67,8 +67,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/xacml/kmarket-trading-sample/pom.xml
+++ b/xacml/kmarket-trading-sample/pom.xml
@@ -55,8 +55,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The product was not built on JDK 14. Updated the source and target versions to 1.8, which is the minimal supported version at present.

**Related PRs:**
https://github.com/wso2/product-is/pull/9131

The above mentioned PR has been rendered obsolete due to the migration of the samples code from [product-is](https://github.com/wso2/product-is) to this repo. 
This PR reflects the changes of the above PR to the relevant samples in this repo.
