### PR TITLE
Improve pickup-dispatch and manager to support OIDC back-channel logout

### DIFF
--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
@@ -47,5 +47,5 @@ public final class OAuth2Constants {
     // Enable or disable OIDCSessionManagement logout.
     public static final String OIDC_SESSION_MANAGEMENT_ENABLED = "enableOIDCSessionManagement";
     // Enable or disable OIDCBackchannel logout.
-    public static final String OIDC_BACK_CHANNEL_LOGOUT_ENABLED = "enableOIDCBCLogout";
+    public static final String OIDC_BACK_CHANNEL_LOGOUT_ENABLED = "enableOIDCBackchannelLogout";
 }

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
@@ -34,7 +34,7 @@ public final class OAuth2Constants {
     public static final String OIDC_LOGOUT_ENDPOINT = "logoutEndpoint";
     public static final String OIDC_SESSION_IFRAME_ENDPOINT = "sessionIFrameEndpoint";
     public static final String NAME = "name";
-    //OIDC Backchannel logout related constants.
+    // OIDC Backchannel logout related constants.
     public static final String SID = "sid";
     public static final String LOGOUT_TOKEN = "logout_token";
 

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
@@ -34,6 +34,9 @@ public final class OAuth2Constants {
     public static final String OIDC_LOGOUT_ENDPOINT = "logoutEndpoint";
     public static final String OIDC_SESSION_IFRAME_ENDPOINT = "sessionIFrameEndpoint";
     public static final String NAME = "name";
+    //OIDC Backchannel logout related constants.
+    public static final String SID = "sid";
+    public static final String LOGOUT_TOKEN = "logout_token";
 
     // application specific session attributes
     public static final String CODE = "code";
@@ -41,4 +44,8 @@ public final class OAuth2Constants {
     // request headers
     public static final String REFERER = "referer";
 
+    // Enable or disable OIDCSessionManagement logout.
+    public static final String OIDC_SESSION_MANAGEMENT_ENABLED = "enableOIDCSessionManagement";
+    // Enable or disable OIDCBackchannel logout.
+    public static final String OIDC_BACK_CHANNEL_LOGOUT_ENABLED = "enableOIDCBCLogout";
 }

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/logout/OIDCBackChannelLogoutServlet.java
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/logout/OIDCBackChannelLogoutServlet.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.sample.identity.oauth2.logout;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.wso2.sample.identity.oauth2.OAuth2Constants;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.logging.Logger;
+
+/**
+ * Servlet for handling BackChannel logout requests.
+ */
+public class OIDCBackChannelLogoutServlet extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(OIDCBackChannelLogoutServlet.class.getName());
+
+    public void init(ServletConfig config) throws SecurityException {
+
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
+            IOException {
+
+        doPost(req, resp);
+    }
+
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
+            IOException {
+
+        LOGGER.info("BackChannel logout request received.");
+
+        String sid = null;
+        try {
+            sid = (String) SignedJWT.parse(req.getParameter(OAuth2Constants.LOGOUT_TOKEN)).getJWTClaimsSet()
+                    .getClaim(OAuth2Constants.SID);
+            LOGGER.info("Logout token: " + req.getParameter(OAuth2Constants.LOGOUT_TOKEN));
+        } catch (ParseException e) {
+            LOGGER.warning("Error while getting Logout Token.");
+        }
+        HttpSession session = SessionIdStore.getSession(sid);
+
+        if (session != null) {
+            session.invalidate();
+            SessionIdStore.removeSession(sid);
+            LOGGER.info("Session invalidated successfully for sid: " + sid);
+        } else {
+            LOGGER.info("Cannot find corresponding session for sid: " + sid);
+        }
+    }
+}

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/logout/SessionIdStore.java
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/org/wso2/sample/identity/oauth2/logout/SessionIdStore.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.sample.identity.oauth2.logout;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.wso2.sample.identity.oauth2.OAuth2Constants;
+
+import javax.servlet.http.HttpSession;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+
+/**
+ * Class for storing HttpSession against sid.
+ */
+public class SessionIdStore {
+
+    private static final Logger LOGGER = Logger.getLogger(SessionIdStore.class.getName());
+    private static Map<String, HttpSession> sessionMap = new HashMap<>();
+
+    public static void storeSession(String sid, HttpSession session) {
+
+        LOGGER.info("Storing session: " + session.getId() + " against the sid: " + sid);
+        sessionMap.put(sid, session);
+    }
+
+    public static String getSid(String idToken) throws ParseException {
+
+        return (String) SignedJWT.parse(idToken).getJWTClaimsSet().getClaim(OAuth2Constants.SID);
+    }
+
+    public static HttpSession getSession(String sid) {
+
+        if (sid != null && sessionMap.get(sid) != null) {
+            LOGGER.info("Retrieving session: " + sessionMap.get(sid).getId() + " for the sid: " + sid);
+            return sessionMap.get(sid);
+        } else {
+            LOGGER.warning("No session found for the sid: " + sid);
+            return null;
+        }
+    }
+
+    public static void removeSession(String sid) {
+
+        sessionMap.remove(sid);
+    }
+}

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/resources/dispatch.properties
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/resources/dispatch.properties
@@ -5,6 +5,9 @@ callBackUrl=http://localhost.com:8080/pickup-dispatch/oauth2client
 scope=openid internal_application_mgt_view
 authzGrantType=code
 
+enableOIDCSessionManagement=true
+enableOIDCBCLogout=false
+
 authzEndpoint=https://localhost:9443/oauth2/authorize
 OIDC_LOGOUT_ENDPOINT=https://localhost:9443/oidc/logout
 sessionIFrameEndpoint=https://localhost:9443/oidc/checksession

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/resources/dispatch.properties
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/resources/dispatch.properties
@@ -6,7 +6,7 @@ scope=openid internal_application_mgt_view
 authzGrantType=code
 
 enableOIDCSessionManagement=true
-enableOIDCBCLogout=false
+enableOIDCBackchannelLogout=false
 
 authzEndpoint=https://localhost:9443/oauth2/authorize
 OIDC_LOGOUT_ENDPOINT=https://localhost:9443/oidc/logout

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/WEB-INF/web.xml
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/WEB-INF/web.xml
@@ -17,10 +17,20 @@
         <servlet-class>org.wso2.sample.identity.oauth2.services.MetadataServlet</servlet-class>
         <load-on-startup>0</load-on-startup>
     </servlet>
+    <servlet>
+        <servlet-name>OIDCBackChannelLogoutServlet</servlet-name>
+        <servlet-class>org.wso2.sample.identity.oauth2.logout.OIDCBackChannelLogoutServlet</servlet-class>
+        <load-on-startup>0</load-on-startup>
+    </servlet>
 
     <servlet-mapping>
         <servlet-name>OAuth2ClientServlet</servlet-name>
         <url-pattern>/oauth2client</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>OIDCBackChannelLogoutServlet</servlet-name>
+        <url-pattern>/bclogout</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/home.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/home.jsp
@@ -28,6 +28,7 @@
 <%@page import="com.nimbusds.jwt.ReadOnlyJWTClaimsSet"%>
 <%@page import="java.util.logging.Logger"%>
 <%@page import="org.wso2.samples.claims.manager.ClaimManagerProxy"%>
+<%@ page import="org.wso2.sample.identity.oauth2.logout.SessionIdStore" %>
 
 <%
     final Logger logger = Logger.getLogger(getClass().getName());
@@ -56,6 +57,19 @@
         try {
             name = SignedJWT.parse(idToken).getJWTClaimsSet().getSubject();
             ReadOnlyJWTClaimsSet claimsSet = SignedJWT.parse(idToken).getJWTClaimsSet();
+
+            // If back-channel logout is enabled, then store the sid claim against the application's session.
+            boolean enableOIDCBCLogout = false;
+            if (session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED) != null) {
+                enableOIDCBCLogout = (boolean) session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED);
+            }
+            if (enableOIDCBCLogout) {
+                logger.info("BackChannel logout is enabled");
+                String sid = SessionIdStore.getSid(idToken);
+                if (sid != null) {
+                    SessionIdStore.storeSession(sid, session);
+                }
+            }
             
             ClaimManagerProxy claimManagerProxy = (ClaimManagerProxy) application.getAttribute("claimManagerProxyInstance");
 
@@ -349,7 +363,17 @@
 <script src="js/custom.v1.0.js"></script>
 <!-- SweetAlerts -->
 <script src="libs/sweetalerts/sweetalert.2.1.2.min.js"></script>
+<%
+    boolean enableOIDCSessionManagement = true;
+    if (session.getAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED) != null){
+        enableOIDCSessionManagement = (boolean)session.getAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED);
+    }
+    if(enableOIDCSessionManagement){
+%>
 <iframe id="rpIFrame" src="rpIFrame.jsp" frameborder="0" width="0" height="0"></iframe>
+<%
+    }
+%>
 <script>
     hljs.initHighlightingOnLoad();
     loadMetadata();

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/home.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/home.jsp
@@ -59,11 +59,11 @@
             ReadOnlyJWTClaimsSet claimsSet = SignedJWT.parse(idToken).getJWTClaimsSet();
 
             // If back-channel logout is enabled, then store the sid claim against the application's session.
-            boolean enableOIDCBCLogout = false;
+            boolean enableOIDCBackchannelLogout = false;
             if (session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED) != null) {
-                enableOIDCBCLogout = (boolean) session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED);
+                enableOIDCBackchannelLogout = (boolean) session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED);
             }
-            if (enableOIDCBCLogout) {
+            if (enableOIDCBackchannelLogout) {
                 logger.info("BackChannel logout is enabled");
                 String sid = SessionIdStore.getSid(idToken);
                 if (sid != null) {

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/oauth2-authorize-user.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/oauth2-authorize-user.jsp
@@ -15,7 +15,9 @@
     String callBackUrl = properties.getProperty("callBackUrl");
     String OIDC_LOGOUT_ENDPOINT = properties.getProperty("OIDC_LOGOUT_ENDPOINT");
     String sessionIFrameEndpoint = properties.getProperty("sessionIFrameEndpoint");
-    
+    boolean enableOIDCSessionManagement = Boolean.parseBoolean(properties.getProperty("enableOIDCSessionManagement"));
+    boolean enableOIDCBCLogout = Boolean.parseBoolean(properties.getProperty("enableOIDCBCLogout"));
+
     session.setAttribute(OAuth2Constants.OAUTH2_GRANT_TYPE, authzGrantType);
     session.setAttribute(OAuth2Constants.CONSUMER_KEY, consumerKey);
     session.setAttribute(OAuth2Constants.SCOPE, scope);
@@ -23,7 +25,9 @@
     session.setAttribute(OAuth2Constants.OAUTH2_AUTHZ_ENDPOINT, authzEndpoint);
     session.setAttribute(OAuth2Constants.OIDC_LOGOUT_ENDPOINT, OIDC_LOGOUT_ENDPOINT);
     session.setAttribute(OAuth2Constants.OIDC_SESSION_IFRAME_ENDPOINT, sessionIFrameEndpoint);
-    
+    session.setAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED, enableOIDCSessionManagement);
+    session.setAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED, enableOIDCBCLogout);
+
     OAuthClientRequest.AuthenticationRequestBuilder oAuthAuthenticationRequestBuilder =
             new OAuthClientRequest.AuthenticationRequestBuilder(authzEndpoint);
     oAuthAuthenticationRequestBuilder

--- a/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/oauth2-authorize-user.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-dispatch/src/main/webapp/oauth2-authorize-user.jsp
@@ -16,7 +16,7 @@
     String OIDC_LOGOUT_ENDPOINT = properties.getProperty("OIDC_LOGOUT_ENDPOINT");
     String sessionIFrameEndpoint = properties.getProperty("sessionIFrameEndpoint");
     boolean enableOIDCSessionManagement = Boolean.parseBoolean(properties.getProperty("enableOIDCSessionManagement"));
-    boolean enableOIDCBCLogout = Boolean.parseBoolean(properties.getProperty("enableOIDCBCLogout"));
+    boolean enableOIDCBackchannelLogout = Boolean.parseBoolean(properties.getProperty("enableOIDCBackchannelLogout"));
 
     session.setAttribute(OAuth2Constants.OAUTH2_GRANT_TYPE, authzGrantType);
     session.setAttribute(OAuth2Constants.CONSUMER_KEY, consumerKey);
@@ -26,7 +26,7 @@
     session.setAttribute(OAuth2Constants.OIDC_LOGOUT_ENDPOINT, OIDC_LOGOUT_ENDPOINT);
     session.setAttribute(OAuth2Constants.OIDC_SESSION_IFRAME_ENDPOINT, sessionIFrameEndpoint);
     session.setAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED, enableOIDCSessionManagement);
-    session.setAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED, enableOIDCBCLogout);
+    session.setAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED, enableOIDCBackchannelLogout);
 
     OAuthClientRequest.AuthenticationRequestBuilder oAuthAuthenticationRequestBuilder =
             new OAuthClientRequest.AuthenticationRequestBuilder(authzEndpoint);

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
@@ -34,10 +34,19 @@ public final class OAuth2Constants {
     public static final String OIDC_SESSION_IFRAME_ENDPOINT = "sessionIFrameEndpoint";
     public static final String NAME = "name";
 
+    //OIDC Backchannel logout related constants.
+    public static final String SID = "sid";
+    public static final String LOGOUT_TOKEN = "logout_token";
+
     // application specific session attributes
     public static final String CODE = "code";
 
     // request headers
     public static final String REFERER = "referer";
+
+    // Enable or disable OIDCSessionManagement logout.
+    public static final String OIDC_SESSION_MANAGEMENT_ENABLED = "enableOIDCSessionManagement";
+    // Enable or disable OIDCBackChannel logout.
+    public static final String OIDC_BACK_CHANNEL_LOGOUT_ENABLED = "enableOIDCBCLogout";
 
 }

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
@@ -47,6 +47,6 @@ public final class OAuth2Constants {
     // Enable or disable OIDCSessionManagement logout.
     public static final String OIDC_SESSION_MANAGEMENT_ENABLED = "enableOIDCSessionManagement";
     // Enable or disable OIDCBackChannel logout.
-    public static final String OIDC_BACK_CHANNEL_LOGOUT_ENABLED = "enableOIDCBCLogout";
+    public static final String OIDC_BACK_CHANNEL_LOGOUT_ENABLED = "enableOIDCBackchannelLogout";
 
 }

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/OAuth2Constants.java
@@ -34,7 +34,7 @@ public final class OAuth2Constants {
     public static final String OIDC_SESSION_IFRAME_ENDPOINT = "sessionIFrameEndpoint";
     public static final String NAME = "name";
 
-    //OIDC Backchannel logout related constants.
+    // OIDC Backchannel logout related constants.
     public static final String SID = "sid";
     public static final String LOGOUT_TOKEN = "logout_token";
 

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/logout/OIDCBackChannelLogoutServlet.java
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/logout/OIDCBackChannelLogoutServlet.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.sample.identity.oauth2.logout;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.wso2.sample.identity.oauth2.OAuth2Constants;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.logging.Logger;
+
+/**
+ * Servlet for handling Backchannel logout requests.
+ */
+public class OIDCBackChannelLogoutServlet extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(OIDCBackChannelLogoutServlet.class.getName());
+
+    public void init(ServletConfig config) throws SecurityException {
+
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
+            IOException {
+
+        doPost(req, resp);
+    }
+
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
+            IOException {
+
+        LOGGER.info("BackChannel logout request received.");
+
+        String sid = null;
+        try {
+            sid = (String) SignedJWT.parse(req.getParameter(OAuth2Constants.LOGOUT_TOKEN)).getJWTClaimsSet().
+                    getClaim(OAuth2Constants.SID);
+            LOGGER.info("Logout token: " + req.getParameter(OAuth2Constants.LOGOUT_TOKEN));
+        } catch (ParseException e) {
+            LOGGER.warning("Error while getting Logout Token.");
+        }
+        HttpSession session = SessionIdStore.getSession(sid);
+
+        if (session != null) {
+            session.invalidate();
+            SessionIdStore.removeSession(sid);
+            LOGGER.info("Session invalidated successfully for sid: " + sid);
+        } else {
+            LOGGER.info("Cannot find corresponding session for sid: " + sid);
+        }
+    }
+}

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/logout/SessionIdStore.java
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/org/wso2/sample/identity/oauth2/logout/SessionIdStore.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.sample.identity.oauth2.logout;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.wso2.sample.identity.oauth2.OAuth2Constants;
+
+import javax.servlet.http.HttpSession;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+
+/**
+ * Xlass for storing HttpSession against sid.
+ */
+public class SessionIdStore {
+
+    private static final Logger LOGGER = Logger.getLogger(SessionIdStore.class.getName());
+    private static Map<String, HttpSession> sessionMap = new HashMap<>();
+
+    public static void storeSession(String sid, HttpSession session) {
+
+        LOGGER.info("Storing session: " + session.getId() + " against the sid: " + sid);
+        sessionMap.put(sid, session);
+    }
+
+    public static String getSid(String idToken) throws ParseException {
+
+        return (String) SignedJWT.parse(idToken).getJWTClaimsSet().getClaim(OAuth2Constants.SID);
+    }
+
+    public static HttpSession getSession(String sid) {
+
+        if (sid != null && sessionMap.get(sid) != null) {
+            LOGGER.info("Retrieving session: " + sessionMap.get(sid).getId() + " for the sid: " + sid);
+            return sessionMap.get(sid);
+        } else {
+            LOGGER.warning("No session found for the sid: " + sid);
+            return null;
+        }
+    }
+
+    public static void removeSession(String sid) {
+
+        sessionMap.remove(sid);
+    }
+}

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/resources/manager.properties
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/resources/manager.properties
@@ -8,6 +8,8 @@ sessionIFrameEndpoint=https://localhost:9443/oidc/checksession
 consumerSecret=c3dpZnRhcHAxMjM=
 tokenEndpoint=https://localhost:9443/oauth2/token
 post_logout_redirect_uri=http://localhost.com:8080/pickup-manager/oauth2client
+enableOIDCSessionManagement=true
+enableOIDCBCLogout=false
 # Used for claim management calls
 claimManagementEndpoint=https://localhost:9443/services/ClaimMetadataManagementService
 adminUsername=admin

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/resources/manager.properties
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/resources/manager.properties
@@ -9,7 +9,7 @@ consumerSecret=c3dpZnRhcHAxMjM=
 tokenEndpoint=https://localhost:9443/oauth2/token
 post_logout_redirect_uri=http://localhost.com:8080/pickup-manager/oauth2client
 enableOIDCSessionManagement=true
-enableOIDCBCLogout=false
+enableOIDCBackchannelLogout=false
 # Used for claim management calls
 claimManagementEndpoint=https://localhost:9443/services/ClaimMetadataManagementService
 adminUsername=admin

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/WEB-INF/web.xml
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/WEB-INF/web.xml
@@ -13,9 +13,20 @@
         <load-on-startup>0</load-on-startup>
     </servlet>
 
+    <servlet>
+        <servlet-name>OIDCBackChannelLogoutServlet</servlet-name>
+        <servlet-class>org.wso2.sample.identity.oauth2.logout.OIDCBackChannelLogoutServlet</servlet-class>
+        <load-on-startup>0</load-on-startup>
+    </servlet>
+
     <servlet-mapping>
         <servlet-name>OAuth2ClientServlet</servlet-name>
         <url-pattern>/oauth2client</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>OIDCBackChannelLogoutServlet</servlet-name>
+        <url-pattern>/bclogout</url-pattern>
     </servlet-mapping>
 
     <listener>

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/home.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/home.jsp
@@ -59,11 +59,11 @@
             ReadOnlyJWTClaimsSet claimsSet = SignedJWT.parse(idToken).getJWTClaimsSet();
 
             // If back-channel logout is enabled, then store the sid claim against the application's session.
-            boolean enableOIDCBCLogout = false;
+            boolean enableOIDCBackchannelLogout = false;
             if (session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED) != null) {
-                enableOIDCBCLogout = (boolean) session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED);
+                enableOIDCBackchannelLogout = (boolean) session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED);
             }
-            if (enableOIDCBCLogout) {
+            if (enableOIDCBackchannelLogout) {
                 logger.info("BackChannel logout is enabled");
                 String sid = SessionIdStore.getSid(idToken);
                 if (sid != null) {

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/home.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/home.jsp
@@ -28,6 +28,7 @@
 <%@page import="java.util.HashMap"%>
 <%@page import="java.util.Map"%>
 <%@page import="org.wso2.samples.claims.manager.ClaimManagerProxy"%>
+<%@ page import="org.wso2.sample.identity.oauth2.logout.SessionIdStore" %>
 
 <%
     final Logger logger = Logger.getLogger(getClass().getName());
@@ -56,6 +57,19 @@
         try {
             name = SignedJWT.parse(idToken).getJWTClaimsSet().getSubject();
             ReadOnlyJWTClaimsSet claimsSet = SignedJWT.parse(idToken).getJWTClaimsSet();
+
+            // If back-channel logout is enabled, then store the sid claim against the application's session.
+            boolean enableOIDCBCLogout = false;
+            if (session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED) != null) {
+                enableOIDCBCLogout = (boolean) session.getAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED);
+            }
+            if (enableOIDCBCLogout) {
+                logger.info("BackChannel logout is enabled");
+                String sid = SessionIdStore.getSid(idToken);
+                if (sid != null) {
+                    SessionIdStore.storeSession(sid, session);
+                }
+            }
 
             ClaimManagerProxy claimManagerProxy = (ClaimManagerProxy) application.getAttribute("claimManagerProxyInstance");
 
@@ -522,7 +536,17 @@
 <script src="libs/clipboard/clipboard.min.js"></script>
 <!-- Custom Js -->
 <script src="js/custom.js"></script>
+<%
+    boolean enableOIDCSessionManagement = true;
+    if (session.getAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED) != null){
+        enableOIDCSessionManagement = (boolean)session.getAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED);
+    }
+    if(enableOIDCSessionManagement){
+%>
 <iframe id="rpIFrame" src="rpIFrame.jsp" frameborder="0" width="0" height="0"></iframe>
+<%
+    }
+%>
 <script>hljs.initHighlightingOnLoad();</script>
 
 </body>

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/oauth2-authorize-user.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/oauth2-authorize-user.jsp
@@ -15,7 +15,9 @@
     String callBackUrl = properties.getProperty("callBackUrl");
     String OIDC_LOGOUT_ENDPOINT = properties.getProperty("OIDC_LOGOUT_ENDPOINT");
     String sessionIFrameEndpoint = properties.getProperty("sessionIFrameEndpoint");
-    
+    boolean enableOIDCSessionManagement = Boolean.parseBoolean(properties.getProperty("enableOIDCSessionManagement"));
+    boolean enableOIDCBCLogout = Boolean.parseBoolean(properties.getProperty("enableOIDCBCLogout"));
+
     session.setAttribute(OAuth2Constants.OAUTH2_GRANT_TYPE, authzGrantType);
     session.setAttribute(OAuth2Constants.CONSUMER_KEY, consumerKey);
     session.setAttribute(OAuth2Constants.SCOPE, scope);
@@ -23,7 +25,9 @@
     session.setAttribute(OAuth2Constants.OAUTH2_AUTHZ_ENDPOINT, authzEndpoint);
     session.setAttribute(OAuth2Constants.OIDC_LOGOUT_ENDPOINT, OIDC_LOGOUT_ENDPOINT);
     session.setAttribute(OAuth2Constants.OIDC_SESSION_IFRAME_ENDPOINT, sessionIFrameEndpoint);
-    
+    session.setAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED, enableOIDCSessionManagement);
+    session.setAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED, enableOIDCBCLogout);
+
     OAuthClientRequest.AuthenticationRequestBuilder oAuthAuthenticationRequestBuilder =
             new OAuthClientRequest.AuthenticationRequestBuilder(authzEndpoint);
     oAuthAuthenticationRequestBuilder

--- a/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/oauth2-authorize-user.jsp
+++ b/sso-samples/oidc-sso-sample/pickup-manager/src/main/webapp/oauth2-authorize-user.jsp
@@ -16,7 +16,7 @@
     String OIDC_LOGOUT_ENDPOINT = properties.getProperty("OIDC_LOGOUT_ENDPOINT");
     String sessionIFrameEndpoint = properties.getProperty("sessionIFrameEndpoint");
     boolean enableOIDCSessionManagement = Boolean.parseBoolean(properties.getProperty("enableOIDCSessionManagement"));
-    boolean enableOIDCBCLogout = Boolean.parseBoolean(properties.getProperty("enableOIDCBCLogout"));
+    boolean enableOIDCBackchannelLogout = Boolean.parseBoolean(properties.getProperty("enableOIDCBackchannelLogout"));
 
     session.setAttribute(OAuth2Constants.OAUTH2_GRANT_TYPE, authzGrantType);
     session.setAttribute(OAuth2Constants.CONSUMER_KEY, consumerKey);
@@ -26,7 +26,7 @@
     session.setAttribute(OAuth2Constants.OIDC_LOGOUT_ENDPOINT, OIDC_LOGOUT_ENDPOINT);
     session.setAttribute(OAuth2Constants.OIDC_SESSION_IFRAME_ENDPOINT, sessionIFrameEndpoint);
     session.setAttribute(OAuth2Constants.OIDC_SESSION_MANAGEMENT_ENABLED, enableOIDCSessionManagement);
-    session.setAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED, enableOIDCBCLogout);
+    session.setAttribute(OAuth2Constants.OIDC_BACK_CHANNEL_LOGOUT_ENABLED, enableOIDCBackchannelLogout);
 
     OAuthClientRequest.AuthenticationRequestBuilder oAuthAuthenticationRequestBuilder =
             new OAuthClientRequest.AuthenticationRequestBuilder(authzEndpoint);


### PR DESCRIPTION
## Purpose
> Add back-channel logout support for pickup-dispatch and pickup-manager. By default, pickup dispatch and manager will support OIDC session management logout for SLO. But by enabling the following configs, we can disable OIDCsessionManagement and enable OIDCBack-channel logout.
```
enableOIDCSessionManagement=false
enableOIDCBCLogout=true
```

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
>To enable back-channel logout for pickup-dispatch/pickup-manager

> 1. Enable OIDC back-channel logout under application configuration in management console.
<img width="686" alt="Screenshot 2020-10-26 at 15 20 40" src="https://user-images.githubusercontent.com/17597293/97158341-49c7c580-179f-11eb-8f77-d232f0ac6020.png">

> 2. Add back-channel logout URL as 
> pickup-manager: http://localhost.com:8080/pickup-manager/bclogout
> pickup-dispatch: http://localhost.com:8080/pickup-dispatch/bclogout
> 3. Add configuration to enableBackChannel logout and disable OIDC session management in dispatch.properties file and manager.properties.
> 

```
enableOIDCSessionManagement=false
enableOIDCBCLogout=true
```

