### PR TITLE
Implement pagination for bulk user export

### DIFF
--- a/bulk-user-export-tool/README.md
+++ b/bulk-user-export-tool/README.md
@@ -18,7 +18,7 @@ Follow these steps to export user data from WSO2 IS
 5. Provide the host address of the Identity Server instance.
 [Note : If you’re getting user data from the super-tenant you only need to provide the host address 
 of the instance(ex : For a local instance https://localhost:9443). If you’re getting data from a tenant you need 
-append `t/<tenant-domain>` to host address (ex: https://localhost:9443/t/wso2).]
+append `t/<tenant-domain>` to host address (ex: https://localhost:9443/t/wso2).] *Default: `https://localhost:9443`*
 6. Provide user credentials of a user with required permissions to call SCIM 2.0 /users endpoint.
 7. Provide location of the CSV file you need to create. This is an **optional** parameter 
 and by default tool will create a users.csv in the tool directory.
@@ -26,7 +26,9 @@ and by default tool will create a users.csv in the tool directory.
 This is also an **optional** input.
 9. Provide attributes that needs to be excluded when creating the CSV. Attributes provided here won’t be in the CSV. 
 This is also an **optional** input.
-10. Now you've successfully created the CSV file containing user data.
+10. Provide the batch count to retrieve the users (Pagination). *Default: 100*
+11. Provide the maximum count of users to be retrieved. *Default: unlimited*
+12. Now you've successfully created the CSV file containing user data.
 
 ## Download and build
 

--- a/bulk-user-export-tool/README.md
+++ b/bulk-user-export-tool/README.md
@@ -17,8 +17,8 @@ Follow these steps to export user data from WSO2 IS
 4. Run `sh start.sh` inside extracted directory.
 5. Provide the host address of the Identity Server instance.
 [Note : If you’re getting user data from the super-tenant you only need to provide the host address 
-of the instance(ex : For a local instance https://localhost:9443). If you’re getting data from a tenant you need 
-append `t/<tenant-domain>` to host address (ex: https://localhost:9443/t/wso2).] *Default: `https://localhost:9443`*
+of the instance(ex : For a local instance `https://localhost:9443`). If you’re getting data from a tenant you need 
+append `t/<tenant-domain>` to host address (ex: `https://localhost:9443/t/wso2`).] *Default: `https://localhost:9443`*
 6. Provide user credentials of a user with required permissions to call SCIM 2.0 /users endpoint.
 7. Provide location of the CSV file you need to create. *Default: `users.csv` in the tool directory*
 8. Provide attributes that needs to be filtered. Created CSV will only have the attributes specified. 

--- a/bulk-user-export-tool/README.md
+++ b/bulk-user-export-tool/README.md
@@ -20,12 +20,11 @@ Follow these steps to export user data from WSO2 IS
 of the instance(ex : For a local instance https://localhost:9443). If you’re getting data from a tenant you need 
 append `t/<tenant-domain>` to host address (ex: https://localhost:9443/t/wso2).] *Default: `https://localhost:9443`*
 6. Provide user credentials of a user with required permissions to call SCIM 2.0 /users endpoint.
-7. Provide location of the CSV file you need to create. This is an **optional** parameter 
-and by default tool will create a users.csv in the tool directory.
+7. Provide location of the CSV file you need to create. *Default: `users.csv` in the tool directory*
 8. Provide attributes that needs to be filtered. Created CSV will only have the attributes specified. 
-This is also an **optional** input.
+This is an **optional** input.
 9. Provide attributes that needs to be excluded when creating the CSV. Attributes provided here won’t be in the CSV. 
-This is also an **optional** input.
+This is an **optional** input.
 10. Provide the batch count to retrieve the users (Pagination). *Default: 100*
 11. Provide the maximum count of users to be retrieved. *Default: unlimited*
 12. Now you've successfully created the CSV file containing user data.

--- a/bulk-user-export-tool/README.md
+++ b/bulk-user-export-tool/README.md
@@ -25,10 +25,12 @@ append `t/<tenant-domain>` to host address (ex: `https://localhost:9443/t/wso2`)
 This is an **optional** input.
 9. Provide attributes that needs to be excluded when creating the CSV. Attributes provided here won’t be in the CSV. 
 This is an **optional** input.
-10. Provide the start index to retrieve the users. *Default: 1*
-11. Provide the batch count to retrieve the users. *Default: 100*
-12. Provide the maximum count of users to be retrieved. *Default: unlimited*
-13. Now you've successfully created the CSV file containing user data.
+10. Provide the userstore domain to be filtered. Created CSV will only have the users from the specified userstore.
+This is an **optional** input.
+11. Provide the start index to retrieve the users. *Default: 1*
+12. Provide the batch count to retrieve the users. *Default: 100*
+13. Provide the maximum count of users to be retrieved. *Default: unlimited*
+14. Now you've successfully created the CSV file containing user data.
 
 ## Download and build
 

--- a/bulk-user-export-tool/README.md
+++ b/bulk-user-export-tool/README.md
@@ -25,9 +25,10 @@ append `t/<tenant-domain>` to host address (ex: `https://localhost:9443/t/wso2`)
 This is an **optional** input.
 9. Provide attributes that needs to be excluded when creating the CSV. Attributes provided here won’t be in the CSV. 
 This is an **optional** input.
-10. Provide the batch count to retrieve the users (Pagination). *Default: 100*
-11. Provide the maximum count of users to be retrieved. *Default: unlimited*
-12. Now you've successfully created the CSV file containing user data.
+10. Provide the start index to retrieve the users. *Default: 1*
+11. Provide the batch count to retrieve the users. *Default: 100*
+12. Provide the maximum count of users to be retrieved. *Default: unlimited*
+13. Now you've successfully created the CSV file containing user data.
 
 ## Download and build
 

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
@@ -15,9 +15,11 @@ read -p "Attributes to filter (Optional) (ex: id,username,emails) : " attributes
 [ -z "$attributes" ] && { attributes=none; }
 read -p "Attributes to exclude (Optional) (ex:groups,emails,name.givenName) : " excludedAttributes
 [ -z "$excludedAttributes" ] && { excludedAttributes=none; }
+read -p "Start Index(Optional) [1]: " startIndex
+[ -z "$startIndex" ] && { startIndex=none; }
 read -p "Batch Count (Optional) [100]: " batchCount
 [ -z "$batchCount" ] && { batchCount=none; }
 read -p "Maximum Count (Optional) [-1]: " maxCount
 [ -z "$maxCount" ] && { maxCount=none; }
 
-java -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $batchCount $maxCount
+java -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $startIndex $batchCount $maxCount

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
@@ -15,7 +15,7 @@ read -p "Attributes to filter (Optional) (ex: id,username,emails) : " attributes
 [ -z "$attributes" ] && { attributes=none; }
 read -p "Attributes to exclude (Optional) (ex:groups,emails,name.givenName) : " excludedAttributes
 [ -z "$excludedAttributes" ] && { excludedAttributes=none; }
-read -p "Start Index(Optional) [1]: " startIndex
+read -p "Start Index (Optional) [1]: " startIndex
 [ -z "$startIndex" ] && { startIndex=none; }
 read -p "Batch Count (Optional) [100]: " batchCount
 [ -z "$batchCount" ] && { batchCount=none; }

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
@@ -13,7 +13,7 @@ read -p "CSV file location (Optional) (ex: path/to/users.csv): " csv
 [ -z "$csv" ] && { csv=none; }
 read -p "Attributes to filter (Optional) (ex: id,username,emails) : " attributes
 [ -z "$attributes" ] && { attributes=none; }
-read -p "Attributes to exclude (Optional) (ex:groups, name_givenName) : " excludedAttributes
+read -p "Attributes to exclude (Optional) (ex:groups,emails,name.givenName) : " excludedAttributes
 [ -z "$excludedAttributes" ] && { excludedAttributes=none; }
 read -p "Batch Count (Optional) [100]: " batchCount
 [ -z "$batchCount" ] && { batchCount=none; }

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
@@ -20,4 +20,4 @@ read -p "Batch Count (Optional) [100]: " batchCount
 read -p "Maximum Count (Optional) [-1]: " maxCount
 [ -z "$maxCount" ] && { maxCount=none; }
 
-java -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005 -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $batchCount $maxCount
+java -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $batchCount $maxCount

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-read -p "Enter host address of WSO2 IS (Required) (ex: https://localhost/9443) : " host
-[ -z "$host" ] && { echo "Error: Host address can't be empty!"; exit 1; }
+read -p "Enter host address of WSO2 IS (Required) [https://localhost:9443] : " host
+[ -z "$host" ] && { host="https://localhost:9443"; }
 read -p "Enter username (Required) : " username
 [ -z "$username" ] && { echo "Error: username can't be empty!"; exit 1; }
 stty -echo
@@ -15,5 +15,9 @@ read -p "Attributes to filter (Optional) (ex: id,username,emails) : " attributes
 [ -z "$attributes" ] && { attributes=none; }
 read -p "Attributes to exclude (Optional) (ex:groups, name_givenName) : " excludedAttributes
 [ -z "$excludedAttributes" ] && { excludedAttributes=none; }
+read -p "Batch Count (Optional) [100]: " batchCount
+[ -z "$batchCount" ] && { batchCount=none; }
+read -p "Maximum Count (Optional) [-1]: " maxCount
+[ -z "$maxCount" ] && { maxCount=none; }
 
-java -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes
+java -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005 -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $batchCount $maxCount

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/scripts/start.sh
@@ -15,6 +15,8 @@ read -p "Attributes to filter (Optional) (ex: id,username,emails) : " attributes
 [ -z "$attributes" ] && { attributes=none; }
 read -p "Attributes to exclude (Optional) (ex:groups,emails,name.givenName) : " excludedAttributes
 [ -z "$excludedAttributes" ] && { excludedAttributes=none; }
+read -p "Userstore domain to filteer (Optional) (ex:PRIMARY) : " userstoreDomain
+[ -z "$userstoreDomain" ] && { userstoreDomain=none; }
 read -p "Start Index (Optional) [1]: " startIndex
 [ -z "$startIndex" ] && { startIndex=none; }
 read -p "Batch Count (Optional) [100]: " batchCount
@@ -22,4 +24,4 @@ read -p "Batch Count (Optional) [100]: " batchCount
 read -p "Maximum Count (Optional) [-1]: " maxCount
 [ -z "$maxCount" ] && { maxCount=none; }
 
-java -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $startIndex $batchCount $maxCount
+java -jar $(find . -name "*scim.bulk.user.export.tool*") $host $username $password $csv $attributes $excludedAttributes $userstoreDomain $startIndex $batchCount $maxCount

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
@@ -40,6 +40,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
@@ -69,8 +70,7 @@ public class BulkExportUsers {
         // ArrayNode to store flattened user information.
         ArrayNode usersArrayNode = new ObjectMapper().createArrayNode();
 
-        Set<String> attributesToExclude = new HashSet<>(Arrays.asList("schemas", "meta_location",
-                "meta_lastModified", "meta_resourceType"));
+        String attributesToExclude = "schemas,meta_location,meta_lastModified,meta_resourceType";
         String hostAddress = args[0];
         String username = args[1];
         String password = args[2];
@@ -89,7 +89,7 @@ public class BulkExportUsers {
         }
 
         if (!NONE.equals(args[5])) {
-            attributesToExclude.addAll(Arrays.asList(args[5].split(",")));
+            attributesToExclude += "," + args[5];
         }
 
         if (!NONE.equals(args[6])) {
@@ -112,6 +112,7 @@ public class BulkExportUsers {
                 builder.setParameter("attributes", attributes);
             }
             LOGGER.log(Level.INFO, "Retrieving " + count + " users starting from: " + startIndex);
+            builder.setParameter("excludedAttributes", attributesToExclude);
             builder.setParameter("startIndex", Integer.toString(startIndex));
             builder.setParameter("count", Integer.toString(count));
             startIndex += count;
@@ -140,7 +141,7 @@ public class BulkExportUsers {
                         for (int i = 0; i < arrayNode.size(); i++) {
                             JsonNode arrayElement = arrayNode.get(i);
                             usersArrayNode.add(JSONFlattener.generateFlatJSON(new ObjectMapper().createObjectNode(),
-                                    arrayElement, null, attributesToExclude));
+                                    arrayElement, null, Collections.emptySet()));
                         }
                     } else {
                         LOGGER.log(Level.INFO, "End of results reached.");

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
@@ -39,10 +39,7 @@ import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +68,7 @@ public class BulkExportUsers {
         ArrayNode usersArrayNode = new ObjectMapper().createArrayNode();
 
         String attributesToExclude = "schemas,meta_location,meta_lastModified,meta_resourceType";
+        String userstoreDomain = null;
         String hostAddress = args[0];
         String username = args[1];
         String password = args[2];
@@ -93,15 +91,19 @@ public class BulkExportUsers {
         }
 
         if (!NONE.equals(args[6])) {
-            startIndex = Integer.parseInt(args[6]);
+            userstoreDomain = args[6];
         }
 
         if (!NONE.equals(args[7])) {
-            count = Integer.parseInt(args[7]);
+            startIndex = Integer.parseInt(args[7]);
         }
 
         if (!NONE.equals(args[8])) {
-            maxCount = Integer.parseInt(args[8]);
+            count = Integer.parseInt(args[8]);
+        }
+
+        if (!NONE.equals(args[9])) {
+            maxCount = Integer.parseInt(args[9]);
         }
 
         // Create a get request to retrieve list users from SCIM 2.0
@@ -112,9 +114,15 @@ public class BulkExportUsers {
                 LOGGER.log(Level.INFO, "Maximum count: " + maxCount + " reached.");
                 break;
             }
+
             if (attributes != null) {
                 builder.setParameter("attributes", attributes);
             }
+
+            if (userstoreDomain != null) {
+                builder.setParameter("domain", userstoreDomain);
+            }
+
             LOGGER.log(Level.INFO, "Retrieving " + count + " users starting from: " + startIndex);
             builder.setParameter("excludedAttributes", attributesToExclude);
             builder.setParameter("startIndex", Integer.toString(startIndex));

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
@@ -34,6 +34,7 @@ import org.apache.http.util.EntityUtils;
 
 import javax.net.ssl.SSLContext;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.KeyManagementException;
@@ -55,7 +56,7 @@ public class BulkExportUsers {
 
     private static final Logger LOGGER = Logger.getLogger(BulkExportUsers.class.getName());
 
-    public static void main(String args[]) throws IOException, KeyStoreException,
+    public static void main(String[] args) throws IOException, KeyStoreException,
             NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
 
         if (args.length < 6) {
@@ -64,9 +65,6 @@ public class BulkExportUsers {
             return;
         }
 
-        // ArrayNode to store flattened user information.
-        ArrayNode usersArrayNode = new ObjectMapper().createArrayNode();
-
         String attributesToExclude = "schemas,meta_location,meta_lastModified,meta_resourceType";
         String userstoreDomain = null;
         String hostAddress = args[0];
@@ -74,7 +72,7 @@ public class BulkExportUsers {
         String password = args[2];
         String csvDirectory = DEFAULT_CSV_FILE;
         int startIndex = START_INDEX;
-        int count = DEFAULT_COUNT;
+        int batchCount = DEFAULT_COUNT;
         int maxCount = MAX_COUNT;
 
         if (!NONE.equals(args[3])) {
@@ -99,16 +97,28 @@ public class BulkExportUsers {
         }
 
         if (!NONE.equals(args[8])) {
-            count = Integer.parseInt(args[8]);
+            batchCount = Integer.parseInt(args[8]);
         }
 
         if (!NONE.equals(args[9])) {
             maxCount = Integer.parseInt(args[9]);
         }
 
-        // Create a get request to retrieve list users from SCIM 2.0
+        // Create a get request to retrieve list users from SCIM 2.0.
         URIBuilder builder = new URIBuilder(hostAddress + PATH_SEPARATOR + SCIM_USER_ENDPOINT);
 
+        // CsvSchema Builder and CsvMapper to generate the csv.
+        CsvSchema.Builder csvSchemaBuilder = CsvSchema.builder();
+        CsvSchema csvSchema = null;
+        CsvMapper csvMapper = new CsvMapper();
+
+        // Initialize the CSV file.
+        File file = new File(csvDirectory);
+
+        // ArrayNode to store flattened user information.
+        ArrayNode usersArrayNode = null;
+
+        boolean isSchemaInitialized = false;
         while (true) {
             if (maxCount != -1 && maxCount < startIndex) {
                 LOGGER.log(Level.INFO, "Maximum count: " + maxCount + " reached.");
@@ -123,13 +133,13 @@ public class BulkExportUsers {
                 builder.setParameter("domain", userstoreDomain);
             }
 
-            LOGGER.log(Level.INFO, "Retrieving " + count + " users starting from: " + startIndex);
             builder.setParameter("excludedAttributes", attributesToExclude);
             builder.setParameter("startIndex", Integer.toString(startIndex));
-            builder.setParameter("count", Integer.toString(count));
-            startIndex += count;
+            builder.setParameter("count", Integer.toString(batchCount));
 
+            LOGGER.log(Level.INFO, "Retrieving " + batchCount + " users starting from: " + startIndex);
             HttpGet request = HttpClient.createGetHttpRequest(builder, username, password);
+            startIndex += batchCount;
 
             final SSLContext sslContext = new SSLContextBuilder()
                     .loadTrustMaterial(null, (x509CertChain, authType) -> true)
@@ -148,6 +158,7 @@ public class BulkExportUsers {
                     JsonNode usersNode = jsonTree.at("/Resources");
 
                     // Create a flattened user information array.
+                    usersArrayNode = new ObjectMapper().createArrayNode();
                     if (usersNode.isArray()) {
                         ArrayNode arrayNode = (ArrayNode) usersNode;
                         for (int i = 0; i < arrayNode.size(); i++) {
@@ -155,7 +166,36 @@ public class BulkExportUsers {
                             usersArrayNode.add(JSONFlattener.generateFlatJSON(new ObjectMapper().createObjectNode(),
                                     arrayElement, null, Collections.emptySet()));
                         }
-                        if (arrayNode.size() < count) {
+
+                        if (!isSchemaInitialized) {
+                            // Initialize the CSV schema only in the first iteration.
+                            for (int i = 0; i < usersArrayNode.size(); i++) {
+                                usersArrayNode.get(i).fieldNames().forEachRemaining(
+                                        fieldName -> {
+                                            if (!csvSchemaBuilder.hasColumn(fieldName)) {
+                                                csvSchemaBuilder.addColumn(fieldName);
+                                            }
+                                        });
+                            }
+                            csvSchema = csvSchemaBuilder.build().withHeader();
+
+                            // Write the user data to csv file.
+                            csvMapper.writerFor(ArrayNode.class)
+                                    .with(csvSchema)
+                                    .writeValue(new FileWriter(file), usersArrayNode);
+
+                            // Remove the header from the CSV schema
+                            csvSchema = csvSchemaBuilder.build();
+
+                            isSchemaInitialized = true;
+                        } else {
+                            // Append the user data to csv file.
+                            csvMapper.writerFor(ArrayNode.class)
+                                    .with(csvSchema)
+                                    .writeValue(new FileWriter(file, true), usersArrayNode);
+                        }
+
+                        if (arrayNode.size() < batchCount) {
                             LOGGER.log(Level.INFO, "End of results reached.");
                             break;
                         }
@@ -165,29 +205,17 @@ public class BulkExportUsers {
                     }
 
                 } else {
-                    LOGGER.log(Level.INFO, request.getMethod() + " Request to " + request.getURI().toString() +
+                    LOGGER.log(Level.SEVERE, request.getMethod() + " Request to " + request.getURI().toString() +
                             " returned the status code : " + response.getStatusLine());
                     return;
                 }
             }
         }
 
-        // Create a csv schema and generate the csv file containing user information.
-        CsvSchema.Builder csvSchemaBuilder = CsvSchema.builder();
-        for (int i = 0; i < usersArrayNode.size(); i++) {
-            usersArrayNode.get(i).fieldNames().forEachRemaining(
-                    fieldName -> {
-                        if (!csvSchemaBuilder.hasColumn(fieldName)) {
-                            csvSchemaBuilder.addColumn(fieldName);
-                        }
-                    });
+        if (isSchemaInitialized) {
+            LOGGER.log(Level.INFO, "User information was successfully written to : " + csvDirectory + " file.");
+        } else {
+            LOGGER.log(Level.WARNING, "Empty results returned. CSV file is not created.");
         }
-        CsvSchema csvSchema = csvSchemaBuilder.build().withHeader();
-
-        CsvMapper csvMapper = new CsvMapper();
-        csvMapper.writerFor(ArrayNode.class)
-                .with(csvSchema)
-                .writeValue(new File(csvDirectory), usersArrayNode);
-        LOGGER.log(Level.INFO, "User information was successfully written to : " + csvDirectory + " file.");
     }
 }

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
@@ -93,11 +93,15 @@ public class BulkExportUsers {
         }
 
         if (!NONE.equals(args[6])) {
-            count = Integer.parseInt(args[6]);
+            startIndex = Integer.parseInt(args[6]);
         }
 
         if (!NONE.equals(args[7])) {
-            maxCount = Integer.parseInt(args[7]);
+            count = Integer.parseInt(args[7]);
+        }
+
+        if (!NONE.equals(args[8])) {
+            maxCount = Integer.parseInt(args[8]);
         }
 
         // Create a get request to retrieve list users from SCIM 2.0
@@ -142,6 +146,10 @@ public class BulkExportUsers {
                             JsonNode arrayElement = arrayNode.get(i);
                             usersArrayNode.add(JSONFlattener.generateFlatJSON(new ObjectMapper().createObjectNode(),
                                     arrayElement, null, Collections.emptySet()));
+                        }
+                        if (arrayNode.size() < count) {
+                            LOGGER.log(Level.INFO, "End of results reached.");
+                            break;
                         }
                     } else {
                         LOGGER.log(Level.INFO, "End of results reached.");

--- a/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
+++ b/bulk-user-export-tool/scim-bulk-user-export-tool/src/main/java/org/wso2/scim/bulk/export/BulkExportUsers.java
@@ -105,11 +105,13 @@ public class BulkExportUsers {
 
         while (true) {
             if (maxCount != -1 && maxCount < startIndex) {
+                LOGGER.log(Level.INFO, "Maximum count: " + maxCount + " reached.");
                 break;
             }
             if (attributes != null) {
                 builder.setParameter("attributes", attributes);
             }
+            LOGGER.log(Level.INFO, "Retrieving " + count + " users starting from: " + startIndex);
             builder.setParameter("startIndex", Integer.toString(startIndex));
             builder.setParameter("count", Integer.toString(count));
             startIndex += count;
@@ -141,6 +143,7 @@ public class BulkExportUsers {
                                     arrayElement, null, attributesToExclude));
                         }
                     } else {
+                        LOGGER.log(Level.INFO, "End of results reached.");
                         break;
                     }
 


### PR DESCRIPTION
## Purpose
1. Currently the [scim-bulk-user-export-tool](https://github.com/wso2/samples-is/tree/master/bulk-user-export-tool/scim-bulk-user-export-tool) doesn't support pagination. This PR implements pagination support for the scim-bulk-user-export-tool, to avoid any memory issues if the user count is in millions.
2. Previously the `excludedAttributes` is filtered out after retrieving the results from the server. This PR avoids retrieving the `excludedAttributes` from the API request itself to improve the performance.
3. Implements support for filter users with userstore domain.