### PR TITLE
Update custom federated authenticator component to be compatible from IS 5.3.0 onwards.

### DIFF
--- a/authenticators/components/org.wso2.carbon.identity.sample.federated.authenticator/pom.xml
+++ b/authenticators/components/org.wso2.carbon.identity.sample.federated.authenticator/pom.xml
@@ -60,6 +60,16 @@
             <artifactId>json-smart</artifactId>
             <version>${json-smart.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-codec.wso2</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <version>${apache.felix.ds.annotations.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>
@@ -97,8 +107,12 @@
                         </Private-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.custom.federated.authenticator.internal,
-                            org.wso2.carbon.identity.custom.federated.authenticator.*; version="1.0.0"
+                            org.wso2.carbon.identity.custom.federated.authenticator.*; version=${project.version}
                         </Export-Package>
+                        <Import-Package>
+                            com.nimbusds.jose.util;version="${nimbusds.osgi.version.range}",
+                            net.minidev.json;version="${json-smart.version.range}"
+                        </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
@@ -107,9 +121,15 @@
     </build>
 
     <properties>
-        <carbon.identity.framework.version>5.18.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.7.5</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
-        <json-smart.version>2.3</json-smart.version>
-        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
+        <json-smart.version>1.3</json-smart.version>
+        <nimbusds.version>2.26.1.wso2v3</nimbusds.version>
+        <apache.felix.ds.annotations.version>1.2.8</apache.felix.ds.annotations.version>
+        <commons-codec.version>1.4.0.wso2v1</commons-codec.version>
+
+        <!-- The following package ranges were defined to make this authenticator compatible from IS 5.3.0 onwards.-->
+        <nimbusds.osgi.version.range>[2.26.0,8.0.0)</nimbusds.osgi.version.range>
+        <json-smart.version.range>[1.3.0,3.0.0)</json-smart.version.range>
     </properties>
 </project>

--- a/authenticators/components/org.wso2.carbon.identity.sample.federated.authenticator/src/main/java/org/wso2/carbon/identity/custom/federated/authenticator/CustomFederatedAuthenticator.java
+++ b/authenticators/components/org.wso2.carbon.identity.sample.federated.authenticator/src/main/java/org/wso2/carbon/identity/custom/federated/authenticator/CustomFederatedAuthenticator.java
@@ -35,10 +35,8 @@ import org.wso2.carbon.identity.application.authentication.framework.FederatedAp
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
-import org.wso2.carbon.identity.core.ServiceURLBuilder;
-import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -264,13 +262,12 @@ public class CustomFederatedAuthenticator extends AbstractApplicationAuthenticat
                     .AUTHORIZATION_CODE).setClientId(clientId).setClientSecret(clientSecret).setRedirectURI
                     (callbackUrl).setCode(authzResponse.getCode()).buildBodyMessage();
             if (accessTokenRequest != null) {
-                String serverURL = ServiceURLBuilder.create().build().getAbsolutePublicURL();
+                String serviceUrl = IdentityUtil.getServicePath();
+                String serverURL = IdentityUtil.getServerURL(serviceUrl, true, true);
                 accessTokenRequest.addHeader(CustomFederatedAuthenticatorConstants.HTTP_ORIGIN_HEADER, serverURL);
             }
         } catch (OAuthSystemException e) {
             throw new AuthenticationFailedException("Error while building access token request", e);
-        } catch (URLBuilderException e) {
-            throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
         }
         return accessTokenRequest;
     }


### PR DESCRIPTION
"Writing a Custom Federated Authenticator" doc from IS 5.3.0 to IS 5.10.0 contains samples in SVN which are inaccessible. Due to this, the custom federated authenticator sample maintained in this repo has being modified to be compatible from IS 5.3.0 so that we can refer to this sample in the relevant docs and remove the SVN location links.

The improvement was tested in IS 5.3.0 and IS 5.9.0