### PR TITLE
Make custom mobile grant compatible with scopes

### DIFF
--- a/oauth2/custom-grant/src/main/java/org/wso2/sample/identity/oauth2/grant/mobile/MobileGrant.java
+++ b/oauth2/custom-grant/src/main/java/org/wso2/sample/identity/oauth2/grant/mobile/MobileGrant.java
@@ -21,7 +21,6 @@ package org.wso2.sample.identity.oauth2.grant.mobile;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.ResponseHeader;
 import org.wso2.carbon.identity.oauth2.model.RequestParameter;
@@ -66,19 +65,16 @@ public class MobileGrant extends AbstractAuthorizationGrantHandler  {
 
             if(authStatus) {
                 // if valid set authorized mobile number as grant user
-                String tenantDomain = MultitenantUtils.getTenantDomain(mobileNumber);
                 String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(mobileNumber);
-                AuthenticatedUser mobileUser = new AuthenticatedUser();
-                mobileUser.setUserName(tenantAwareUsername);
-                mobileUser.setTenantDomain(tenantDomain);
                 /*
-                   Set the federated IdP name as "LOCAL" to avoid constraint violation errors. If a federated user is
-                   involved with this custom grant then, the federated IdP name and the other claims should be fetched
-                   accordingly.
+                    Please use AuthenticatedUser.createFederateAuthenticatedUserFromSubjectIdentifier() if a federated
+                    user is involved with this custom grant.
                  */
-                mobileUser.setFederatedIdPName(FrameworkConstants.LOCAL_IDP_NAME);
-                mobileUser.setAuthenticatedSubjectIdentifier(mobileNumber);
-                mobileUser.setFederatedUser(true);
+                AuthenticatedUser mobileUser = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(
+                        tenantAwareUsername);
+                // Set the federated IdP name if a federated user is involved with this custom grant.
+                // mobileUser.setFederatedIdPName(FrameworkConstants.LOCAL_IDP_NAME);
+
                 oAuthTokenReqMessageContext.setAuthorizedUser(mobileUser);
                 oAuthTokenReqMessageContext.setScope(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO().getScope());
             } else{

--- a/oauth2/custom-grant/src/main/java/org/wso2/sample/identity/oauth2/grant/mobile/MobileGrant.java
+++ b/oauth2/custom-grant/src/main/java/org/wso2/sample/identity/oauth2/grant/mobile/MobileGrant.java
@@ -21,6 +21,7 @@ package org.wso2.sample.identity.oauth2.grant.mobile;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.ResponseHeader;
 import org.wso2.carbon.identity.oauth2.model.RequestParameter;
@@ -70,6 +71,12 @@ public class MobileGrant extends AbstractAuthorizationGrantHandler  {
                 AuthenticatedUser mobileUser = new AuthenticatedUser();
                 mobileUser.setUserName(tenantAwareUsername);
                 mobileUser.setTenantDomain(tenantDomain);
+                /*
+                   Set the federated IdP name as "LOCAL" to avoid constraint violation errors. If a federated user is
+                   involved with this custom grant then, the federated IdP name and the other claims should be fetched
+                   accordingly.
+                 */
+                mobileUser.setFederatedIdPName(FrameworkConstants.LOCAL_IDP_NAME);
                 mobileUser.setAuthenticatedSubjectIdentifier(mobileNumber);
                 mobileUser.setFederatedUser(true);
                 oAuthTokenReqMessageContext.setAuthorizedUser(mobileUser);

--- a/oauth2/custom-grant/src/main/java/org/wso2/sample/identity/oauth2/grant/mobile/MobileGrant.java
+++ b/oauth2/custom-grant/src/main/java/org/wso2/sample/identity/oauth2/grant/mobile/MobileGrant.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.oauth2.ResponseHeader;
 import org.wso2.carbon.identity.oauth2.model.RequestParameter;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 /**
  * New grant type for Identity Server
@@ -64,8 +65,11 @@ public class MobileGrant extends AbstractAuthorizationGrantHandler  {
 
             if(authStatus) {
                 // if valid set authorized mobile number as grant user
+                String tenantDomain = MultitenantUtils.getTenantDomain(mobileNumber);
+                String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(mobileNumber);
                 AuthenticatedUser mobileUser = new AuthenticatedUser();
-                mobileUser.setUserName(mobileNumber);
+                mobileUser.setUserName(tenantAwareUsername);
+                mobileUser.setTenantDomain(tenantDomain);
                 mobileUser.setAuthenticatedSubjectIdentifier(mobileNumber);
                 mobileUser.setFederatedUser(true);
                 oAuthTokenReqMessageContext.setAuthorizedUser(mobileUser);


### PR DESCRIPTION
- The custom mobile grant fails with the following error when scopes are used in the token request.
```
TID: [-1234] [] [2022-05-26 21:36:08,198] [75821185-4e2d-40d9-8b24-fa98bdefeb9b] ERROR {org.wso2.carbon.identity.oauth2.OAuth2Service} - Error occurred while issuing the access token for Client ID : 6y2kZk1m56PMxKi1423vcvr02a4a, User ID null, Scope : [openid] and Grant Type : mobile org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception: Error occurred while storing new access token : 27e1c804-8055-3b6a-8b2e-5ad21b3a55b6
	...
Caused by: org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception: Error when storing the access token for consumer key : 6y2kZk1m56PMxKi1423vcvr02a4a
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:287)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:102)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:326)
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.storeAccessToken(AbstractAuthorizationGrantHandler.java:305)
	... 69 more
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: The INSERT statement conflicted with the FOREIGN KEY constraint "FK__IDN_OAUTH__TOKEN__155B1B70". The conflict occurred in database "ims", table "wso2.IDN_OAUTH2_ACCESS_TOKEN", column 'TOKEN_ID'.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:262)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.getNextResult(SQLServerStatement.java:1632)
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.doExecutePreparedStatement(SQLServerPreparedStatement.java:600)
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement$PrepStmtExecCmd.doExecute(SQLServerPreparedStatement.java:522)
	at com.microsoft.sqlserver.jdbc.TDSCommand.execute(IOBuffer.java:7225)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.executeCommand(SQLServerConnection.java:3053)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeCommand(SQLServerStatement.java:247)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeStatement(SQLServerStatement.java:222)
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.execute(SQLServerPreparedStatement.java:503)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.tomcat.jdbc.pool.StatementFacade$StatementProxy.invoke(StatementFacade.java:114)
	at com.sun.proxy.$Proxy58.execute(Unknown Source)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:235)
	... 72 more
```
- This pull request will resolve this issue by setting the tenant domain and the tenant aware username to the user.