### PR TITLE
Add Support for JDK 11/17 during Artifact Binding Flow

### DIFF
--- a/sso-samples/saml2-sso-sample/saml2-web-app-pickup-dispatch/pom.xml
+++ b/sso-samples/saml2-sso-sample/saml2-web-app-pickup-dispatch/pom.xml
@@ -142,6 +142,11 @@
             <artifactId>claim-manager</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>javax.xml.soap-api</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sso-samples/saml2-sso-sample/saml2-web-app-pickup-dispatch/pom.xml
+++ b/sso-samples/saml2-sso-sample/saml2-web-app-pickup-dispatch/pom.xml
@@ -147,6 +147,11 @@
             <artifactId>javax.xml.soap-api</artifactId>
             <version>1.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+            <version>1.5.1</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Adding missing dependencies to support artifact binding flow after updating the IS to JDK 11 or 17.