### PR TITLE
Remove IDP entity ID update from resident idp update soap request body in QSG script

### DIFF
--- a/quick-start-guide/src/main/resources/bin/qsg.sh
+++ b/quick-start-guide/src/main/resources/bin/qsg.sh
@@ -391,13 +391,6 @@ echo " <soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelop
                         <xsd:value>localhost</xsd:value>
                     </xsd:properties>
                 </xsd:federatedAuthenticatorConfigs>
-                <xsd:federatedAuthenticatorConfigs xmlns=\"http://model.common.application.identity.carbon.wso2.org/xsd\">
-                    <xsd:name>openidconnect</xsd:name>
-                    <xsd:properties>
-                        <xsd:name>IdPEntityId</xsd:name>
-                        <xsd:value>https://${is_host}:${is_port}/oauth2/token</xsd:value>
-                    </xsd:properties>
-                </xsd:federatedAuthenticatorConfigs>
                 <!--Optional:-->
                 <xsd:homeRealmId>localhost</xsd:homeRealmId>
                 <!--Optional:-->
@@ -623,13 +616,6 @@ echo " <soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelop
                     <xsd:properties>
                         <xsd:name>IdPEntityId</xsd:name>
                         <xsd:value>localhost</xsd:value>
-                    </xsd:properties>
-                </xsd:federatedAuthenticatorConfigs>
-                <xsd:federatedAuthenticatorConfigs xmlns=\"http://model.common.application.identity.carbon.wso2.org/xsd\">
-                    <xsd:name>openidconnect</xsd:name>
-                    <xsd:properties>
-                        <xsd:name>IdPEntityId</xsd:name>
-                        <xsd:value>https://${is_host}:${is_port}/oauth2/token</xsd:value>
                     </xsd:properties>
                 </xsd:federatedAuthenticatorConfigs>
                 <!--Optional:-->


### PR DESCRIPTION
## Purpose
Resolve https://github.com/wso2/product-is/issues/14880

## Approach
In the soap request sent to update the resident IDP configurations in order to enable self registration, IDP entity id value is also updated with the hostname and port specified in the server.properties file. But updating the IDP entity ID value is not required for the scenario in the self sign up quick start guide to work as expected. Due to updating this value as mentioned in the issue, myaccount and console application login is broken due to updating the IDP entity ID. This PR removes the IDP entity ID from the soap request body to keep the myaccount and console applications functioning properly when trying the QSG.