### PR TITLE
Modify backend-service to run on JDK 11

### DIFF
--- a/etc/backend-service/pom.xml
+++ b/etc/backend-service/pom.xml
@@ -38,6 +38,14 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -664,6 +664,20 @@
                 <artifactId>gson</artifactId>
                 <version>${com.google.code.gson.version}</version>
             </dependency>
+            <!--=============================================================================-->
+
+            <!--dependencies of backend-service-->
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${javax.annotation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${javax.xml.bind.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -887,6 +901,12 @@
         <nimbusds.osgi.version.range>[2.26.0,8.0.0)</nimbusds.osgi.version.range>
         <json-smart.version.range>[1.3.0,3.0.0)</json-smart.version.range>
         <oauth2.outbound.version.range>[1.0.5, 2.0.0)</oauth2.outbound.version.range>
+
+        <!--=============================================================================-->
+
+        <!--repo versions of backend-service-->
+        <javax.annotation.version>1.2</javax.annotation.version>
+        <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
> Following error occurs when the Backend-service runs on Java 11.
```WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/C:/Users/Lenovo/Downloads/IAM_5.10.Samples-master/IAM_5.10.Samples-master/Access_Delegation_Samples/backend-service.jar) to constructor java.nio.DirectByteBuffer(long,int)
WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Exception in thread "main" java.lang.NoClassDefFoundError: javax/annotation/PostConstruct
at org.wso2.msf4j.internal.router.MicroserviceMetadata.lambda$new$33(MicroserviceMetadata.java:63)
at java.base/java.util.HashMap.forEach(HashMap.java:1336)
at java.base/java.util.Collections$UnmodifiableMap.forEach(Collections.java:1505)
at org.wso2.msf4j.internal.router.MicroserviceMetadata.(MicroserviceMetadata.java:61)
at org.wso2.msf4j.internal.MicroservicesRegistryImpl.updateMetadata(MicroservicesRegistryImpl.java:234)
at org.wso2.msf4j.internal.MicroservicesRegistryImpl.addService(MicroservicesRegistryImpl.java:80)
at org.wso2.msf4j.MicroservicesRunner.deploy(MicroservicesRunner.java:111)
at org.wso2.sample.identity.backend.BackendApplication.main(BackendApplication.java:116)
Caused by: java.lang.ClassNotFoundException: javax.annotation.PostConstruct
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
```

## Goals
> Add dependencies required for JDK 11

