### PR TITLE
Fix build issue with JDK 11

### DIFF
--- a/event-handler/custom-identity-event-handler/pom.xml
+++ b/event-handler/custom-identity-event-handler/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
-                <version>1.7.2</version>
                 <executions>
                     <execution>
                         <id>generate-scr-scrdescriptor</id>


### PR DESCRIPTION
## Purpose
> org.wso2.carbon.identity.customhandler is not getting built when using JDK 11

## Approach
> Remove and upgrade a unsupported dependency version
