### PR TITLE
Add a config to add myaccount app url. 

### DIFF
--- a/petcare-sample/b2c/web-app/petdesk/web/react/config.js
+++ b/petcare-sample/b2c/web-app/petdesk/web/react/config.js
@@ -3,6 +3,7 @@ window.config = {
     clientID: "<CONFIGURED_SPA_CLIENT_ID>",
     signInRedirectURL: "http://localhost:5173",
     signOutRedirectURL: "http://localhost:5173",
+    myAccountAppURL: "",
     resourceServerURL: "http://localhost:9090",
     scope: ["openid", "email", "profile"]
  };

--- a/petcare-sample/b2c/web-app/petdesk/web/react/src/components/UserMenu.tsx
+++ b/petcare-sample/b2c/web-app/petdesk/web/react/src/components/UserMenu.tsx
@@ -67,7 +67,7 @@ export default function MenuListComposition(props: {
     };
 
     const gotoMyAccount = () => {
-        window.open(getConfig().baseUrl + '/myaccount', '_blank');
+        window.open(getConfig().myAccountAppURL, '_blank');
     };
 
     return (

--- a/petcare-sample/b2c/web-app/petdesk/web/react/src/util/getConfig.tsx
+++ b/petcare-sample/b2c/web-app/petdesk/web/react/src/util/getConfig.tsx
@@ -22,6 +22,7 @@ interface Config {
     scope: string[];
     signInRedirectURL: string;
     signOutRedirectURL: string;
+    myAccountAppURL: string;
     resourceServerURL: string;
   }
 
@@ -36,6 +37,7 @@ const authConfig = {
     clientID: window.config.clientID,
     signInRedirectURL: window.config.signInRedirectURL,
     signOutRedirectURL: window.config.signOutRedirectURL,
+    myAccountAppURL: window.config.myAccountAppURL,
     resourceServerURL: window.config.resourceServerURL,
     scope: ["openid", "profile", "email"],
   };


### PR DESCRIPTION
## Purpose
If my account app URL differs from the base URL of the product from app side we need to have a configuration to define the myaccount app URL rather than constructing that on top of the base URL.
This is specifically needed when this app is used with Asgardeo as asgardeo api URL and my account app URL domains differ

## Approach
A config is introduced to configure the myaccount URL