### PR TITLE
Add DPoP proof generator

### DIFF
--- a/oauth2/org.wso2.dpop.proof.generator/README.md
+++ b/oauth2/org.wso2.dpop.proof.generator/README.md
@@ -18,7 +18,7 @@ Ensure you have the following installed:
 1. Clone the repository:
 2. Navigate to the project directory:
    ```sh
-   cd dpop/dpop-proof-generator
+   cd org.wso2.dpop.proof.generator
    ```
 3. Build the project using Maven:
    ```sh
@@ -34,7 +34,7 @@ In this method, you generate a key pair once and use it for multiple requests.
 1. Navigate to the project folder:
 2. Run the following command to generate the key pair:
    ```sh
-   java -cp target/client-app-1.0-jar-with-dependencies.jar org.wso2.dpop.client.GeneratePublicKeyPair
+   java -cp target/org.wso2.dpop.proof.generator-(*)-jar-with-dependenciess.jar org.wso2.dpop.proof.generator.GeneratePublicKeyPair
    ```
    This will generate two files:
     - `dpop.key` (Private Key)
@@ -44,7 +44,7 @@ In this method, you generate a key pair once and use it for multiple requests.
 
 1. Run the following command:
    ```sh
-   java -cp target/client-app-1.0-jar-with-dependencies.jar org.wso2.dpop.client.DPOPProofGeneratorFromPP
+   java -cp target/org.wso2.dpop.proof.generator-(*)-jar-with-dependenciess.jar org.wso2.dpop.proof.generator.DPOPProofGenerator
    ```
 2. Enter the requested inputs:
    ```

--- a/oauth2/org.wso2.dpop.proof.generator/README.md
+++ b/oauth2/org.wso2.dpop.proof.generator/README.md
@@ -1,0 +1,65 @@
+# DPoP Client Application
+
+This client application can be used as stand alone application to generate dpop proofs.
+Source code for DPoP can be found here: https://github.com/wso2-extensions/identity-oauth-dpop
+
+
+## Setup Instructions
+
+### Prerequisites
+
+Ensure you have the following installed:
+
+- **Java** (JDK 8 or later)
+- **Maven**
+
+### Steps to Set Up
+
+1. Clone the repository:
+2. Navigate to the project directory:
+   ```sh
+   cd dpop/dpop-proof-generator
+   ```
+3. Build the project using Maven:
+   ```sh
+   mvn clean install
+   ```
+
+## Generating DPoP Proof Using Pre-Generated Key Pair
+
+In this method, you generate a key pair once and use it for multiple requests.
+
+#### Step 1: Generate a Public-Private Key Pair
+
+1. Navigate to the project folder:
+2. Run the following command to generate the key pair:
+   ```sh
+   java -cp target/client-app-1.0-jar-with-dependencies.jar org.wso2.dpop.client.GeneratePublicKeyPair
+   ```
+   This will generate two files:
+    - `dpop.key` (Private Key)
+    - `dpop.pub` (Public Key)
+
+#### Step 2: Generate DPoP Proof Using Pre-Generated Keys
+
+1. Run the following command:
+   ```sh
+   java -cp target/client-app-1.0-jar-with-dependencies.jar org.wso2.dpop.client.DPOPProofGeneratorFromPP
+   ```
+2. Enter the requested inputs:
+   ```
+   File path to private key: dpop.key
+   File path to public key: dpop.pub
+   Enter the public and private key pair type (EC or RSA): EC
+   Enter the HTTP Method: POST
+   Enter the HTTP URL: https://localhost:9443/oauth2/token
+   ```
+3. Extract the DPoP proof from the output:
+   ```
+   [Signed JWT]: eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJ4Ijoi...
+   ```
+
+---
+
+This guide ensures a smooth setup and usage experience for generating DPoP proofs using pre-generated key pairs.
+

--- a/oauth2/org.wso2.dpop.proof.generator/README.md
+++ b/oauth2/org.wso2.dpop.proof.generator/README.md
@@ -3,7 +3,6 @@
 This client application can be used as stand alone application to generate dpop proofs.
 Source code for DPoP can be found here: https://github.com/wso2-extensions/identity-oauth-dpop
 
-
 ## Setup Instructions
 
 ### Prerequisites

--- a/oauth2/org.wso2.dpop.proof.generator/pom.xml
+++ b/oauth2/org.wso2.dpop.proof.generator/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/oauth2/org.wso2.dpop.proof.generator/pom.xml
+++ b/oauth2/org.wso2.dpop.proof.generator/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.samples.is</groupId>
+        <artifactId>wso2is-identity-samples-oauth2</artifactId>
+        <version>4.6.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.dpop.proof.generator</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <name>OAuth 2.0 DPoP Proof Generator</name>
+    <url>http://maven.apache.org</url>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>lib/*.jar</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>${maven.scr.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4.1</version>
+                <configuration>
+                    <!-- get all project dependencies -->
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <!-- bind to the packaging phase -->
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/Constant.java
+++ b/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/Constant.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.dpop.proof.generator;
+
+import com.nimbusds.jose.JOSEObjectType;
+
+/**
+ * Constant class for DPoP Proof generator.
+ */
+public class Constant {
+
+    public static final String EC = "EC";
+    public static final String RSA = "RSA";
+    public static final String PUB_KEY_FILE_NAME = "dpop.pub";
+    public static final String PRIVATE_KEY_FILE_NAME = "dpop.key";
+    public static final String ISSUER = "wso2_dpop_client";
+    public static final String SUBJECT = "sub";
+    public static final String CLAIM_HTM = "htm";
+    public static final String CLAIM_HTU = "htu";
+    public static final String CLAIM_ATH = "ath";
+    public static final long EXPIRATION_TIME_MILLIS = 86400000L; // 24 hours
+    public static final String DPOP_JWT_TYPE = "dpop+jwt";
+}

--- a/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/DPOPProofGenerator.java
+++ b/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/DPOPProofGenerator.java
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.dpop.proof.generator;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Generates a DPoP (Demonstrating Proof-of-Possession) proof using an existing key pair.
+ * <p>
+ * This class loads a private and public key from specified file paths and generates a signed JWT,
+ * following the OAuth 2.0 DPoP Proof JWT format.
+ * </p>
+ */
+public class DPOPProofGenerator {
+
+    private static final Log log = LogFactory.getLog(DPOPProofGenerator.class);
+
+    public static void main(String[] args) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+
+            // Get user input with validation
+            String privateKeyPath = promptUser(reader, "Enter the file path to private key: ");
+            String publicKeyPath = promptUser(reader, "Enter the file path to public key: ");
+
+            String keyPairType;
+            while (true) {
+                keyPairType = promptUser(reader, "Enter the key pair type (EC or RSA): ").toUpperCase();
+                if (keyPairType.equals("EC") || keyPairType.equals("RSA")) {
+                    break;
+                }
+                log.warn("Invalid key pair type. Please enter 'EC' or 'RSA'.");
+            }
+
+            String httpMethod = promptUser(reader, "Enter the HTTP method (e.g., GET, POST): ");
+            String httpUrl = promptUser(reader, "Enter the HTTP URL: ");
+            log.info("Enter the access token (Press enter " +
+                    "if you don't want to include ath claim: ");
+            String accessToken = reader.readLine().trim();
+
+            // Generate DPoP proof
+            generateDPoPProof(privateKeyPath, publicKeyPath, keyPairType, httpMethod, httpUrl, accessToken);
+
+        } catch (IOException e) {
+            log.error("Error reading user input: ", e);
+        } catch (Exception e) {
+            log.error("An error occurred while generating the DPoP proof: ", e);
+        }
+    }
+
+    private static String promptUser(BufferedReader reader, String message) throws IOException {
+
+        String input;
+        while (true) {
+            log.info(message);
+            input = reader.readLine().trim();
+            if (!input.isEmpty()) {
+                return input;
+            }
+            log.warn("Input cannot be empty. Please try again.");
+        }
+    }
+    /**
+     * Generates a signed DPoP JWT using the provided key files.
+     *
+     * @param privateKeyPath Path to the private key file.
+     * @param publicKeyPath  Path to the public key file.
+     * @param keyPairType    Key type (EC or RSA).
+     * @param httpMethod     HTTP method (e.g., GET, POST).
+     * @param httpUrl        Target HTTP URL.
+     * @throws Exception If an error occurs during key loading or JWT signing.
+     */
+    private static void generateDPoPProof(String privateKeyPath, String publicKeyPath, String keyPairType,
+                                          String httpMethod, String httpUrl, String accessToken) throws Exception {
+
+        // Load keys
+        PrivateKey privateKey = loadPrivateKey(privateKeyPath, keyPairType);
+        PublicKey publicKey = loadPublicKey(publicKeyPath, keyPairType);
+
+        // Create JWK (JSON Web Key)
+        JWK jwk = createJWK(keyPairType, publicKey);
+
+        // Build JWT claims
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.issuer("wso2_dpop_client")
+                .subject("sub")
+                .issueTime(new Date())
+                .jwtID(UUID.randomUUID().toString())
+                .notBeforeTime(new Date())
+                .claim("htm", httpMethod)
+                .claim("htu", httpUrl)
+                .expirationTime(new Date(System.currentTimeMillis() + 86400000L));
+        if (StringUtils.isNotBlank(accessToken)) {
+            log.info("access token: " + accessToken);
+            jwtClaimsSetBuilder.claim("ath", generateAccessTokenHash(accessToken));
+        }
+
+        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
+
+        // Create JWT Header
+        JWSHeader.Builder headerBuilder = ("EC".equals(keyPairType))
+                ? new JWSHeader.Builder(JWSAlgorithm.ES256)
+                : new JWSHeader.Builder(JWSAlgorithm.RS256);
+
+        headerBuilder.type(new JOSEObjectType("dpop+jwt"));
+        headerBuilder.jwk(jwk);
+
+        // Sign JWT
+        SignedJWT signedJWT = new SignedJWT(headerBuilder.build(), jwtClaimsSet);
+        signJWT(signedJWT, privateKey, keyPairType);
+
+        // Log results
+        log.info("[Signed JWT] : " + signedJWT.serialize());
+        log.info("[ThumbPrint] : " + jwk.computeThumbprint().toString());
+    }
+
+    /**
+     * Loads a private key from a file.
+     *
+     * @param keyPath    Path to the private key file.
+     * @param keyType    Key type (EC or RSA).
+     * @return PrivateKey object.
+     * @throws IOException, NoSuchAlgorithmException, InvalidKeySpecException
+     */
+    private static PrivateKey loadPrivateKey(String keyPath, String keyType)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] keyBytes = Files.readAllBytes(Paths.get(keyPath));
+        KeyFactory keyFactory = KeyFactory.getInstance(keyType);
+        return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+    }
+
+    /**
+     * Loads a public key from a file.
+     *
+     * @param keyPath    Path to the public key file.
+     * @param keyType    Key type (EC or RSA).
+     * @return PublicKey object.
+     * @throws IOException, NoSuchAlgorithmException, InvalidKeySpecException
+     */
+    private static PublicKey loadPublicKey(String keyPath, String keyType)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] keyBytes = Files.readAllBytes(Paths.get(keyPath));
+        KeyFactory keyFactory = KeyFactory.getInstance(keyType);
+        return keyFactory.generatePublic(new X509EncodedKeySpec(keyBytes));
+    }
+
+    /**
+     * Creates a JSON Web Key (JWK) from the public key.
+     *
+     * @param keyPairType Key type (EC or RSA).
+     * @param publicKey   The generated public key.
+     * @return JWK object.
+     */
+    private static JWK createJWK(String keyPairType, PublicKey publicKey) {
+        return "EC".equals(keyPairType)
+                ? new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey).build()
+                : new RSAKey.Builder((RSAPublicKey) publicKey).build();
+    }
+
+    /**
+     * Signs a JWT using the private key.
+     *
+     * @param signedJWT   The JWT to be signed.
+     * @param privateKey  The private key.
+     * @param keyPairType The key type (EC or RSA).
+     * @throws JOSEException If an error occurs while signing the JWT.
+     */
+    private static void signJWT(SignedJWT signedJWT, PrivateKey privateKey, String keyPairType) throws JOSEException {
+        if ("EC".equals(keyPairType)) {
+            signedJWT.sign(new ECDSASigner(privateKey, Curve.P_256));
+        } else {
+            signedJWT.sign(new RSASSASigner(privateKey));
+        }
+    }
+
+    private static String generateAccessTokenHash(String accessToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashedBytes = digest.digest(accessToken.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hashedBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not found.", e);
+        }
+    }
+}

--- a/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/GeneratePublicKeyPair.java
+++ b/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/GeneratePublicKeyPair.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.dpop.proof.generator;
+
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.Curve;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.*;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Scanner;
+
+/**
+ * Utility class to generate a public-private key pair and store them in files.
+ * <p>
+ * This class allows the user to generate key pairs of type EC (Elliptic Curve) or RSA,
+ * and saves the keys in separate files (`dpop.key` for the private key and `dpop.pub` for the public key).
+ * </p>
+ */
+public class GeneratePublicKeyPair {
+
+    private static final Log log = LogFactory.getLog(GeneratePublicKeyPair.class);
+    private static final String EC = "EC";
+    private static final String RSA = "RSA";
+    private static final String PUB_KEY_FILE_NAME = "dpop.pub";
+    private static final String PRIVATE_KEY_FILE_NAME = "dpop.key";
+
+
+    public static void main(String[] args) {
+
+        try (Scanner scanner = new Scanner(System.in)) {
+            log.info("Enter the public and private key pair type (EC or RSA): ");
+            String keyPairType = scanner.nextLine().trim().toUpperCase();
+
+            if (!EC.equals(keyPairType) && !RSA.equals(keyPairType)) {
+                log.error("Invalid key pair type. Please enter 'EC' or 'RSA'.");
+                return;
+            }
+
+            KeyPair keyPair = generateKeyPair(keyPairType);
+            JWK jwk = generateJWK(keyPairType, keyPair);
+
+            log.info("Generated JWK: " + jwk);
+
+            saveKeyToFile(PRIVATE_KEY_FILE_NAME, keyPair.getPrivate().getEncoded());
+            saveKeyToFile(PUB_KEY_FILE_NAME, keyPair.getPublic().getEncoded());
+
+            log.info("Keys generated successfully.");
+        } catch (Exception e) {
+            log.error("Error generating key pair: ", e);
+        }
+    }
+
+    /**
+     * Generates a key pair of the specified type (EC or RSA).
+     *
+     * @param keyPairType The type of key pair (EC or RSA).
+     * @return The generated key pair.
+     * @throws NoSuchAlgorithmException If the specified algorithm is not available.
+     * @throws InvalidAlgorithmParameterException If invalid parameters are provided.
+     */
+    private static KeyPair generateKeyPair(String keyPairType)
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(keyPairType);
+
+        if (EC.equals(keyPairType)) {
+            keyPairGenerator.initialize(Curve.P_256.toECParameterSpec());
+        } else {
+            keyPairGenerator.initialize(2048);
+        }
+
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    /**
+     * Generates a JWK (JSON Web Key) representation of the given key pair.
+     *
+     * @param keyPairType The type of key pair (EC or RSA).
+     * @param keyPair The generated key pair.
+     * @return The corresponding JWK object.
+     */
+    private static JWK generateJWK(String keyPairType, KeyPair keyPair) {
+        if (EC.equals(keyPairType)) {
+            return new ECKey.Builder(Curve.P_256, (ECPublicKey) keyPair.getPublic()).build();
+        } else {
+            return new RSAKey.Builder((RSAPublicKey) keyPair.getPublic()).build();
+        }
+    }
+
+    /**
+     * Saves the given key bytes to a file.
+     *
+     * @param filename The name of the file to save the key.
+     * @param keyBytes The key bytes to write to the file.
+     */
+    private static void saveKeyToFile(String filename, byte[] keyBytes) {
+        try (FileOutputStream out = new FileOutputStream(filename)) {
+            out.write(keyBytes);
+        } catch (IOException e) {
+            log.error("Error saving key to file: " + filename, e);
+        }
+    }
+}

--- a/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/GeneratePublicKeyPair.java
+++ b/oauth2/org.wso2.dpop.proof.generator/src/main/java/org/wso2/dpop/proof/generator/GeneratePublicKeyPair.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -33,6 +33,11 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Scanner;
 
+import static org.wso2.dpop.proof.generator.Constant.EC;
+import static org.wso2.dpop.proof.generator.Constant.PRIVATE_KEY_FILE_NAME;
+import static org.wso2.dpop.proof.generator.Constant.PUB_KEY_FILE_NAME;
+import static org.wso2.dpop.proof.generator.Constant.RSA;
+
 /**
  * Utility class to generate a public-private key pair and store them in files.
  * <p>
@@ -43,11 +48,6 @@ import java.util.Scanner;
 public class GeneratePublicKeyPair {
 
     private static final Log log = LogFactory.getLog(GeneratePublicKeyPair.class);
-    private static final String EC = "EC";
-    private static final String RSA = "RSA";
-    private static final String PUB_KEY_FILE_NAME = "dpop.pub";
-    private static final String PRIVATE_KEY_FILE_NAME = "dpop.key";
-
 
     public static void main(String[] args) {
 
@@ -104,6 +104,7 @@ public class GeneratePublicKeyPair {
      * @return The corresponding JWK object.
      */
     private static JWK generateJWK(String keyPairType, KeyPair keyPair) {
+
         if (EC.equals(keyPairType)) {
             return new ECKey.Builder(Curve.P_256, (ECPublicKey) keyPair.getPublic()).build();
         } else {
@@ -118,6 +119,7 @@ public class GeneratePublicKeyPair {
      * @param keyBytes The key bytes to write to the file.
      */
     private static void saveKeyToFile(String filename, byte[] keyBytes) {
+
         try (FileOutputStream out = new FileOutputStream(filename)) {
             out.write(keyBytes);
         } catch (IOException e) {

--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -33,6 +33,7 @@
         <module>playground2</module>
         <module>custom-grant</module>
         <module>custom-token-issuer</module>
+        <module>org.wso2.dpop.proof.generator</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
This client application can be used as stand alone application to generate dpop proofs.
Source code for DPoP can be found here: https://github.com/wso2-extensions/identity-oauth-dpop

This has 2 classes:
- GeneratePublicKeyPair: Utility class to generate a public-private key pair and store them in files.
- DPOPProofGenerator: Generates a DPoP (Demonstrating Proof-of-Possession) proof using an existing key pair

PR is derived from: https://github.com/wso2/samples-is/pull/302/files